### PR TITLE
chore: Port mirror AssemblyScript examples definitions

### DIFF
--- a/checkout/typescript/payment-methods/default/src/index.ts
+++ b/checkout/typescript/payment-methods/default/src/index.ts
@@ -9,7 +9,11 @@ export const main = (payload: Payload): Output => {
     sortResponse: {
       proposedOrder: payload.input.paymentMethods,
     },
-    filterResponse: null,
-    renameResponse: null,
+    filterResponse: {
+      hiddenMethods: [],
+    },
+    renameResponse: {
+      renameProposals: [],
+    },
   };
 };

--- a/checkout/typescript/payment-methods/filter-based-on-configuration/src/index.test.ts
+++ b/checkout/typescript/payment-methods/filter-based-on-configuration/src/index.test.ts
@@ -12,9 +12,9 @@ describe('filter based on configuration', () => {
       },
     });
 
-    expect(renameResponse).toBe(null);
+    expect(renameResponse).toEqual({renameProposals: []});
     expect(filterResponse).toEqual({hiddenMethods: []});
-    expect(sortResponse).toBe(null);
+    expect(sortResponse).toEqual({proposedOrder: []});
   });
 
   it('should not filter if the total price is less than the threshold', () => {
@@ -34,15 +34,15 @@ describe('filter based on configuration', () => {
       },
     });
 
+    expect(renameResponse).toEqual({renameProposals: []});
     expect(filterResponse).toEqual({hiddenMethods: []});
-    expect(renameResponse).toBe(null);
-    expect(sortResponse).toBe(null);
+    expect(sortResponse).toEqual({proposedOrder: []});
   });
 
   it('should filter if the payment method name matches and the price is above the threshold', () => {
     const {renameResponse, sortResponse, filterResponse} = main(input as any);
-    expect(renameResponse).toBe(null);
-    expect(sortResponse).toBe(null);
+    expect(renameResponse).toEqual({renameProposals: []});
+    expect(sortResponse).toEqual({proposedOrder: []});
     expect(filterResponse).toEqual({
       hiddenMethods: [{id: 123456789, name: 'Shopify payments', cards: ['Visa', 'Mastercard', 'Discover']}],
     });

--- a/checkout/typescript/payment-methods/filter-based-on-configuration/src/index.ts
+++ b/checkout/typescript/payment-methods/filter-based-on-configuration/src/index.ts
@@ -12,11 +12,15 @@ export const main = (payload: Payload): Output => {
   const totalPrice = proposalTotalPrice(purchaseProposal);
 
   return {
-    sortResponse: null,
+    sortResponse: {
+      proposedOrder: [],
+    },
     filterResponse: {
       hiddenMethods: paymentMethods.filter((method) => method.name === name && totalPrice.gt(configuredThreshold)),
     },
-    renameResponse: null,
+    renameResponse: {
+      renameProposals: [],
+    },
   };
 };
 

--- a/checkout/typescript/payment-methods/rename-first-method/src/index.ts
+++ b/checkout/typescript/payment-methods/rename-first-method/src/index.ts
@@ -4,8 +4,8 @@ type Payload = PaymentMethodsAPI.Payload;
 type Output = PaymentMethodsAPI.Output;
 
 export const main = ({input}: Payload): Output => ({
-  sortResponse: null,
-  filterResponse: null,
+  sortResponse: {proposedOrder: []},
+  filterResponse: {hiddenMethods: []},
   renameResponse: rename(input.paymentMethods),
 });
 

--- a/checkout/typescript/payment-methods/rename-method-on-configuration/src/index.ts
+++ b/checkout/typescript/payment-methods/rename-method-on-configuration/src/index.ts
@@ -5,8 +5,8 @@ type Output = PaymentMethodsAPI.Output;
 type Configuration = Configuration.Configuration;
 
 export const main = ({input, configuration}: Payload): Output => ({
-  sortResponse: null,
-  filterResponse: null,
+  sortResponse: {proposedOrder: []},
+  filterResponse: {hiddenMethods: []},
   renameResponse: {
     renameProposals: rename(input.paymentMethods, configuration),
   },

--- a/checkout/typescript/payment-methods/sorting-example/src/index.ts
+++ b/checkout/typescript/payment-methods/sorting-example/src/index.ts
@@ -13,8 +13,8 @@ export const main = ({input, configuration}: Payload): Output => ({
   sortResponse: {
     proposedOrder: sort(input.paymentMethods, configuration),
   },
-  filterResponse: null,
-  renameResponse: null,
+  filterResponse: {hiddenMethods: []},
+  renameResponse: {renameProposals: []},
 });
 
 const sort = (methods: Array<PaymentMethod>, conf: Configuration): Array<PaymentMethod> => {

--- a/checkout/typescript/shipping-methods/default/src/index.ts
+++ b/checkout/typescript/shipping-methods/default/src/index.ts
@@ -9,7 +9,11 @@ export const main = (payload: Payload): Output => {
     sortResponse: {
       proposedOrder: payload.input.shippingMethods,
     },
-    filterResponse: null,
-    renameResponse: null,
+    filterResponse: {
+      hiddenMethods: [],
+    },
+    renameResponse: {
+      renameProposals: [],
+    },
   };
 };

--- a/checkout/typescript/shipping-methods/filter-based-on-configuration/src/index.test.ts
+++ b/checkout/typescript/shipping-methods/filter-based-on-configuration/src/index.test.ts
@@ -12,9 +12,9 @@ describe('filter based on configuration', () => {
       },
     });
 
-    expect(renameResponse).toBe(null);
+    expect(renameResponse).toEqual({renameProposals: []});
     expect(filterResponse).toEqual({hiddenMethods: []});
-    expect(sortResponse).toBe(null);
+    expect(sortResponse).toEqual({proposedOrder: []});
   });
 
   it('should not filter if the total price is less than the threshold', () => {
@@ -34,15 +34,15 @@ describe('filter based on configuration', () => {
       },
     });
 
+    expect(renameResponse).toEqual({renameProposals: []});
     expect(filterResponse).toEqual({hiddenMethods: []});
-    expect(renameResponse).toBe(null);
-    expect(sortResponse).toBe(null);
+    expect(sortResponse).toEqual({proposedOrder: []});
   });
 
   it('should filter if the shipping method name matches and the price is above the threshold', () => {
     const {renameResponse, sortResponse, filterResponse} = main(input as any);
-    expect(renameResponse).toBe(null);
-    expect(sortResponse).toBe(null);
+    expect(renameResponse).toEqual({renameProposals: []});
+    expect(sortResponse).toEqual({proposedOrder: []});
     expect(filterResponse).toEqual({
       hiddenMethods: [
         {

--- a/checkout/typescript/shipping-methods/filter-based-on-configuration/src/index.ts
+++ b/checkout/typescript/shipping-methods/filter-based-on-configuration/src/index.ts
@@ -12,11 +12,15 @@ export const main = (payload: Payload): Output => {
   const totalPrice = proposalTotalPrice(purchaseProposal);
 
   return {
-    sortResponse: null,
+    sortResponse: {
+      proposedOrder: [],
+    },
     filterResponse: {
       hiddenMethods: shippingMethods.filter((method) => method.title === name && totalPrice.gt(configuredThreshold)),
     },
-    renameResponse: null,
+    renameResponse: {
+      renameProposals: [],
+    },
   };
 };
 

--- a/checkout/typescript/shipping-methods/rate-naming-per-province-or-country/src/index.ts
+++ b/checkout/typescript/shipping-methods/rate-naming-per-province-or-country/src/index.ts
@@ -11,8 +11,8 @@ enum ProvinceCodeMatchType {
 }
 
 export const main = ({input, configuration}: Payload): Output => ({
-  sortResponse: null,
-  filterResponse: null,
+  sortResponse: {proposedOrder: []},
+  filterResponse: {hiddenMethods: []},
   renameResponse: rename(input, configuration),
 });
 

--- a/checkout/typescript/shipping-methods/rename-first-method/src/index.ts
+++ b/checkout/typescript/shipping-methods/rename-first-method/src/index.ts
@@ -4,8 +4,8 @@ type Payload = ShippingMethodsAPI.Payload;
 type Output = ShippingMethodsAPI.Output;
 
 export const main = ({input}: Payload): Output => ({
-  sortResponse: null,
-  filterResponse: null,
+  sortResponse: {proposedOrder: []},
+  filterResponse: {hiddenMethods: []},
   renameResponse: rename(input.shippingMethods),
 });
 

--- a/checkout/typescript/shipping-methods/sorting-example/src/index.ts
+++ b/checkout/typescript/shipping-methods/sorting-example/src/index.ts
@@ -13,8 +13,8 @@ export const main = ({input, configuration}: Payload): Output => ({
   sortResponse: {
     proposedOrder: sort(input.shippingMethods, configuration),
   },
-  filterResponse: null,
-  renameResponse: null,
+  filterResponse: {hiddenMethods: []},
+  renameResponse: {renameProposals: []},
 });
 
 const sort = (methods: Array<ShippingMethod>, conf: Configuration): Array<ShippingMethod> => {


### PR DESCRIPTION
@mcvinci FYI I've updated the examples to mirror AssemblyScript examples, mostly due the bug/unresolved issue described here https://github.com/Shopify/extension-points/pull/415#issue-738129617; once we settle on if we should change core or the API definition the examples might change again. 