### PR TITLE
Update AS binary output to script.wasm

### DIFF
--- a/checkout/assemblyscript/payment-methods/default/package.json
+++ b/checkout/assemblyscript/payment-methods/default/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "test": "asp --summary --verbose",
-    "build": "shopify-scripts-toolchain-as build --src src/shopify_main.ts --binary build/payment-methods-default.wasm --metadata build/metadata.json --domain checkout --ep payment-methods -- --lib node_modules --optimize --use Date="
+    "build": "shopify-scripts-toolchain-as build --src src/shopify_main.ts --binary build/script.wasm --metadata build/metadata.json --domain checkout --ep payment-methods -- --lib node_modules --optimize --use Date="
   },
   "engines": {
     "node": ">=14.5.0"

--- a/checkout/assemblyscript/shipping-methods/default/package.json
+++ b/checkout/assemblyscript/shipping-methods/default/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "asp --summary --verbose",
-    "build": "shopify-scripts-toolchain-as build --src src/shopify_main.ts --binary build/shipping-methods-default.wasm --metadata build/metadata.json --domain checkout --ep shipping-methods -- --lib node_modules --optimize --use Date="
+    "build": "shopify-scripts-toolchain-as build --src src/shopify_main.ts --binary build/script.wasm --metadata build/metadata.json --domain checkout --ep shipping-methods -- --lib node_modules --optimize --use Date="
   },
   "engines": {
     "node": ">=14.5.0"


### PR DESCRIPTION
During the E2E testing today, I encountered a strange bug where subsequent script pushes weren't being reflected. After some debugging, I found that the CLI was pushing the old binary on subsequent pushes. This was happening because of some legacy fallback behaviour, which I've described in the related issue.

There are two components to this fix:
1. The `build` command in `package.json` should always output to `script.wasm`, which is what it was pre-sparse checkout. This stops us from running into this issue for newly created scripts now.
2. The CLI should be updated to drop the legacy fallback logic. This fallback was introduced ~5 months ago, so it should be safe to drop.

This PR addresses component (1).

Related issue: https://github.com/Shopify/script-service/issues/3804