### PR TITLE
Checkout API library name shuffle

### DIFF
--- a/checkout/typescript/payment-methods/default/jest.config.js
+++ b/checkout/typescript/payment-methods/default/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
     "^.+\\.(ts|tsx|js)$": "babel-jest"
   },
   transformIgnorePatterns: [
-    "node_modules/(?!@shopify\/scripts-checkout-apis-temp/.+\\.js$)"
+    "node_modules/(?!@shopify\/scripts-checkout-apis/.+\\.js$)"
   ],
 }
 

--- a/checkout/typescript/payment-methods/default/package.json
+++ b/checkout/typescript/payment-methods/default/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@shopify/scripts-checkout-apis-temp": "0.1.0"
+    "@shopify/scripts-checkout-apis": "2.0.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.15.4",

--- a/checkout/typescript/payment-methods/default/src/index.ts
+++ b/checkout/typescript/payment-methods/default/src/index.ts
@@ -4,7 +4,7 @@
  * for the payment methods API.
  */
 
-import {PaymentMethodsAPI} from '@shopify/scripts-checkout-apis-temp';
+import {PaymentMethodsAPI} from '@shopify/scripts-checkout-apis';
 
 type Payload = PaymentMethodsAPI.Payload;
 type Output = PaymentMethodsAPI.Output;

--- a/checkout/typescript/payment-methods/filter-payment-methods-based-on-configuration/jest.config.js
+++ b/checkout/typescript/payment-methods/filter-payment-methods-based-on-configuration/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
     "^.+\\.(ts|tsx|js)$": "babel-jest"
   },
   transformIgnorePatterns: [
-    "node_modules/(?!@shopify\/scripts-checkout-apis-temp/.+\\.js$)"
+    "node_modules/(?!@shopify\/scripts-checkout-apis/.+\\.js$)"
   ],
 }
 

--- a/checkout/typescript/payment-methods/filter-payment-methods-based-on-configuration/package.json
+++ b/checkout/typescript/payment-methods/filter-payment-methods-based-on-configuration/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@shopify/scripts-checkout-apis-temp": "0.1.0"
+    "@shopify/scripts-checkout-apis": "2.0.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.15.4",

--- a/checkout/typescript/payment-methods/filter-payment-methods-based-on-configuration/src/index.ts
+++ b/checkout/typescript/payment-methods/filter-payment-methods-based-on-configuration/src/index.ts
@@ -5,7 +5,7 @@
  *     from the configuration in CAD, or $100.00 CAD if the field wasn't set in the configuration.
  */
 
-import {Money, PurchaseProposal, PaymentMethodsAPI, Configuration, Currency} from '@shopify/scripts-checkout-apis-temp';
+import {Money, PurchaseProposal, PaymentMethodsAPI, Configuration, Currency} from '@shopify/scripts-checkout-apis';
 
 type Payload = PaymentMethodsAPI.Payload;
 type Output = PaymentMethodsAPI.Output;

--- a/checkout/typescript/payment-methods/rename-first-payment-method/jest.config.js
+++ b/checkout/typescript/payment-methods/rename-first-payment-method/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
     "^.+\\.(ts|tsx|js)$": "babel-jest"
   },
   transformIgnorePatterns: [
-    "node_modules/(?!@shopify\/scripts-checkout-apis-temp/.+\\.js$)"
+    "node_modules/(?!@shopify\/scripts-checkout-apis/.+\\.js$)"
   ],
 }
 

--- a/checkout/typescript/payment-methods/rename-first-payment-method/package.json
+++ b/checkout/typescript/payment-methods/rename-first-payment-method/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@shopify/scripts-checkout-apis-temp": "0.1.0"
+    "@shopify/scripts-checkout-apis": "2.0.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.15.4",

--- a/checkout/typescript/payment-methods/rename-first-payment-method/src/index.ts
+++ b/checkout/typescript/payment-methods/rename-first-payment-method/src/index.ts
@@ -4,7 +4,7 @@
  *
  */
 
-import {PaymentMethodsAPI, PaymentMethod} from '@shopify/scripts-checkout-apis-temp';
+import {PaymentMethodsAPI, PaymentMethod} from '@shopify/scripts-checkout-apis';
 
 type Payload = PaymentMethodsAPI.Payload;
 type Output = PaymentMethodsAPI.Output;

--- a/checkout/typescript/payment-methods/rename-payment-method-on-configuration/jest.config.js
+++ b/checkout/typescript/payment-methods/rename-payment-method-on-configuration/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
     "^.+\\.(ts|tsx|js)$": "babel-jest"
   },
   transformIgnorePatterns: [
-    "node_modules/(?!@shopify\/scripts-checkout-apis-temp/.+\\.js$)"
+    "node_modules/(?!@shopify\/scripts-checkout-apis/.+\\.js$)"
   ],
 }
 

--- a/checkout/typescript/payment-methods/rename-payment-method-on-configuration/package.json
+++ b/checkout/typescript/payment-methods/rename-payment-method-on-configuration/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@shopify/scripts-checkout-apis-temp": "0.1.0"
+    "@shopify/scripts-checkout-apis": "2.0.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.15.4",

--- a/checkout/typescript/payment-methods/rename-payment-method-on-configuration/src/index.ts
+++ b/checkout/typescript/payment-methods/rename-payment-method-on-configuration/src/index.ts
@@ -8,7 +8,7 @@
  * that the rename will be performed on the first matching method only
  *
  */
-import {PaymentMethodsAPI, Configuration, PaymentMethod} from '@shopify/scripts-checkout-apis-temp';
+import {PaymentMethodsAPI, Configuration, PaymentMethod} from '@shopify/scripts-checkout-apis';
 
 type Payload = PaymentMethodsAPI.Payload;
 type Output = PaymentMethodsAPI.Output;

--- a/checkout/typescript/payment-methods/sort-payment-methods/jest.config.js
+++ b/checkout/typescript/payment-methods/sort-payment-methods/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
     "^.+\\.(ts|tsx|js)$": "babel-jest"
   },
   transformIgnorePatterns: [
-    "node_modules/(?!@shopify\/scripts-checkout-apis-temp/.+\\.js$)"
+    "node_modules/(?!@shopify\/scripts-checkout-apis/.+\\.js$)"
   ],
 }
 

--- a/checkout/typescript/payment-methods/sort-payment-methods/package.json
+++ b/checkout/typescript/payment-methods/sort-payment-methods/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@shopify/scripts-checkout-apis-temp": "0.1.0"
+    "@shopify/scripts-checkout-apis": "2.0.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.15.4",

--- a/checkout/typescript/payment-methods/sort-payment-methods/src/index.ts
+++ b/checkout/typescript/payment-methods/sort-payment-methods/src/index.ts
@@ -11,7 +11,7 @@
  *
  */
 
-import {PaymentMethodsAPI, Configuration, PaymentMethod} from '@shopify/scripts-checkout-apis-temp';
+import {PaymentMethodsAPI, Configuration, PaymentMethod} from '@shopify/scripts-checkout-apis';
 
 type Payload = PaymentMethodsAPI.Payload;
 type Output = PaymentMethodsAPI.Output;

--- a/checkout/typescript/shipping-methods/append-messages-to-shipping-options-based-on-configuration/jest.config.js
+++ b/checkout/typescript/shipping-methods/append-messages-to-shipping-options-based-on-configuration/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
     "^.+\\.(ts|tsx|js)$": "babel-jest"
   },
   transformIgnorePatterns: [
-    "node_modules/(?!@shopify\/scripts-checkout-apis-temp/.+\\.js$)"
+    "node_modules/(?!@shopify\/scripts-checkout-apis/.+\\.js$)"
   ],
 }
 

--- a/checkout/typescript/shipping-methods/append-messages-to-shipping-options-based-on-configuration/package.json
+++ b/checkout/typescript/shipping-methods/append-messages-to-shipping-options-based-on-configuration/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@shopify/scripts-checkout-apis-temp": "0.1.0"
+    "@shopify/scripts-checkout-apis": "2.0.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.15.4",

--- a/checkout/typescript/shipping-methods/append-messages-to-shipping-options-based-on-configuration/src/index.ts
+++ b/checkout/typescript/shipping-methods/append-messages-to-shipping-options-based-on-configuration/src/index.ts
@@ -14,7 +14,7 @@
  * of its name with a dash (`-`) as a separator.
  */
 
-import {ShippingMethodsAPI, Configuration, Address} from '@shopify/scripts-checkout-apis-temp';
+import {ShippingMethodsAPI, Configuration, Address} from '@shopify/scripts-checkout-apis';
 
 type Payload = ShippingMethodsAPI.Payload;
 type Output = ShippingMethodsAPI.Output;

--- a/checkout/typescript/shipping-methods/default/jest.config.js
+++ b/checkout/typescript/shipping-methods/default/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
     "^.+\\.(ts|tsx|js)$": "babel-jest"
   },
   transformIgnorePatterns: [
-    "node_modules/(?!@shopify\/scripts-checkout-apis-temp/.+\\.js$)"
+    "node_modules/(?!@shopify\/scripts-checkout-apis/.+\\.js$)"
   ],
 }
 

--- a/checkout/typescript/shipping-methods/default/package.json
+++ b/checkout/typescript/shipping-methods/default/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@shopify/scripts-checkout-apis-temp": "0.1.0"
+    "@shopify/scripts-checkout-apis": "2.0.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.15.4",

--- a/checkout/typescript/shipping-methods/default/src/index.ts
+++ b/checkout/typescript/shipping-methods/default/src/index.ts
@@ -4,7 +4,7 @@
  * for the shipping methods API.
  */
 
-import {ShippingMethodsAPI} from '@shopify/scripts-checkout-apis-temp';
+import {ShippingMethodsAPI} from '@shopify/scripts-checkout-apis';
 
 type Payload = ShippingMethodsAPI.Payload;
 type Output = ShippingMethodsAPI.Output;

--- a/checkout/typescript/shipping-methods/filter-shipping-methods-based-on-configuration/jest.config.js
+++ b/checkout/typescript/shipping-methods/filter-shipping-methods-based-on-configuration/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
     "^.+\\.(ts|tsx|js)$": "babel-jest"
   },
   transformIgnorePatterns: [
-    "node_modules/(?!@shopify\/scripts-checkout-apis-temp/.+\\.js$)"
+    "node_modules/(?!@shopify\/scripts-checkout-apis/.+\\.js$)"
   ],
 }
 

--- a/checkout/typescript/shipping-methods/filter-shipping-methods-based-on-configuration/package.json
+++ b/checkout/typescript/shipping-methods/filter-shipping-methods-based-on-configuration/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@shopify/scripts-checkout-apis-temp": "0.1.0"
+    "@shopify/scripts-checkout-apis": "2.0.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.15.4",

--- a/checkout/typescript/shipping-methods/filter-shipping-methods-based-on-configuration/src/index.ts
+++ b/checkout/typescript/shipping-methods/filter-shipping-methods-based-on-configuration/src/index.ts
@@ -7,13 +7,7 @@
  *
  */
 
-import {
-  Money,
-  PurchaseProposal,
-  ShippingMethodsAPI,
-  Configuration,
-  Currency,
-} from '@shopify/scripts-checkout-apis-temp';
+import {Money, PurchaseProposal, ShippingMethodsAPI, Configuration, Currency} from '@shopify/scripts-checkout-apis';
 
 type Payload = ShippingMethodsAPI.Payload;
 type Output = ShippingMethodsAPI.Output;

--- a/checkout/typescript/shipping-methods/rename-first-shipping-method/jest.config.js
+++ b/checkout/typescript/shipping-methods/rename-first-shipping-method/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
     "^.+\\.(ts|tsx|js)$": "babel-jest"
   },
   transformIgnorePatterns: [
-    "node_modules/(?!@shopify\/scripts-checkout-apis-temp/.+\\.js$)"
+    "node_modules/(?!@shopify\/scripts-checkout-apis/.+\\.js$)"
   ],
 }
 

--- a/checkout/typescript/shipping-methods/rename-first-shipping-method/package.json
+++ b/checkout/typescript/shipping-methods/rename-first-shipping-method/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@shopify/scripts-checkout-apis-temp": "0.1.0"
+    "@shopify/scripts-checkout-apis": "2.0.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.15.4",

--- a/checkout/typescript/shipping-methods/rename-first-shipping-method/src/index.ts
+++ b/checkout/typescript/shipping-methods/rename-first-shipping-method/src/index.ts
@@ -3,7 +3,7 @@
  * if there are one or more shipping methods.
  *
  */
-import {ShippingMethodsAPI, ShippingMethod} from '@shopify/scripts-checkout-apis-temp';
+import {ShippingMethodsAPI, ShippingMethod} from '@shopify/scripts-checkout-apis';
 
 type Payload = ShippingMethodsAPI.Payload;
 type Output = ShippingMethodsAPI.Output;

--- a/checkout/typescript/shipping-methods/sort-shipping-methods/jest.config.js
+++ b/checkout/typescript/shipping-methods/sort-shipping-methods/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
     "^.+\\.(ts|tsx|js)$": "babel-jest"
   },
   transformIgnorePatterns: [
-    "node_modules/(?!@shopify\/scripts-checkout-apis-temp/.+\\.js$)"
+    "node_modules/(?!@shopify\/scripts-checkout-apis/.+\\.js$)"
   ],
 }
 

--- a/checkout/typescript/shipping-methods/sort-shipping-methods/package.json
+++ b/checkout/typescript/shipping-methods/sort-shipping-methods/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@shopify/scripts-checkout-apis-temp": "0.1.0"
+    "@shopify/scripts-checkout-apis": "2.0.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.15.4",

--- a/checkout/typescript/shipping-methods/sort-shipping-methods/src/index.ts
+++ b/checkout/typescript/shipping-methods/sort-shipping-methods/src/index.ts
@@ -8,7 +8,7 @@
  *    then the script raises an error.
  */
 
-import {ShippingMethodsAPI, Configuration, ShippingMethod} from '@shopify/scripts-checkout-apis-temp';
+import {ShippingMethodsAPI, Configuration, ShippingMethod} from '@shopify/scripts-checkout-apis';
 
 type Payload = ShippingMethodsAPI.Payload;
 type Output = ShippingMethodsAPI.Output;


### PR DESCRIPTION
Copy over changes from https://github.com/Shopify/scripts-apis/pull/456.

This should not be merged until https://github.com/Shopify/shopify-cli/pull/1727 has been merged and a new version in the CLI has been released.