### PR TITLE
Update example scripts to use javy via the shopify-cli command

### DIFF
--- a/checkout/typescript/payment-methods/default/package.json
+++ b/checkout/typescript/payment-methods/default/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "compile": "tsc",
     "prebuild": "webpack",
-    "build": "javy build/index.js -o build/index.wasm",
+    "build": "shopify script javy build/index.js -o build/index.wasm",
     "gen-metadata": "get-api-metadata payment-methods build/metadata.json",
     "test": "tsc --noEmit && jest"
   },

--- a/checkout/typescript/payment-methods/filter-payment-methods-based-on-configuration/package.json
+++ b/checkout/typescript/payment-methods/filter-payment-methods-based-on-configuration/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "compile": "tsc",
     "prebuild": "webpack",
-    "build": "javy build/index.js -o build/index.wasm",
+    "build": "shopify script javy build/index.js -o build/index.wasm",
     "test": "tsc --noEmit && jest",
     "gen-metadata": "get-api-metadata payment-methods build/metadata.json"
   },

--- a/checkout/typescript/payment-methods/rename-first-payment-method/package.json
+++ b/checkout/typescript/payment-methods/rename-first-payment-method/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "compile": "tsc",
     "prebuild": "webpack",
-    "build": "javy build/index.js -o build/index.wasm",
+    "build": "shopify script javy build/index.js -o build/index.wasm",
     "gen-metadata": "get-api-metadata payment-methods build/metadata.json",
     "test": "tsc --noEmit && jest"
   },

--- a/checkout/typescript/payment-methods/rename-payment-method-on-configuration/package.json
+++ b/checkout/typescript/payment-methods/rename-payment-method-on-configuration/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "compile": "tsc",
     "prebuild": "webpack",
-    "build": "javy build/index.js -o build/index.wasm",
+    "build": "shopify script javy build/index.js -o build/index.wasm",
     "gen-metadata": "get-api-metadata payment-methods build/metadata.json",
     "test": "tsc --noEmit && jest"
   },

--- a/checkout/typescript/payment-methods/sort-payment-methods/package.json
+++ b/checkout/typescript/payment-methods/sort-payment-methods/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "compile": "tsc",
     "prebuild": "webpack",
-    "build": "javy build/index.js -o build/index.wasm",
+    "build": "shopify script javy build/index.js -o build/index.wasm",
     "gen-metadata": "get-api-metadata payment-methods build/metadata.json",
     "test": "tsc --noEmit && jest"
   },

--- a/checkout/typescript/shipping-methods/append-messages-to-shipping-options-based-on-configuration/package.json
+++ b/checkout/typescript/shipping-methods/append-messages-to-shipping-options-based-on-configuration/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "compile": "tsc",
     "prebuild": "webpack",
-    "build": "javy build/index.js -o build/index.wasm",
+    "build": "shopify script javy build/index.js -o build/index.wasm",
     "gen-metadata": "get-api-metadata shipping-methods build/metadata.json",
     "test": "tsc --noEmit && jest"
   },

--- a/checkout/typescript/shipping-methods/default/package.json
+++ b/checkout/typescript/shipping-methods/default/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "compile": "tsc",
     "prebuild": "webpack",
-    "build": "javy build/index.js -o build/index.wasm",
+    "build": "shopify script javy build/index.js -o build/index.wasm",
     "gen-metadata": "get-api-metadata shipping-methods build/metadata.json",
     "test": "tsc --noEmit && jest"
   },

--- a/checkout/typescript/shipping-methods/filter-shipping-methods-based-on-configuration/package.json
+++ b/checkout/typescript/shipping-methods/filter-shipping-methods-based-on-configuration/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "compile": "tsc",
     "prebuild": "webpack",
-    "build": "javy build/index.js -o build/index.wasm",
+    "build": "shopify script javy build/index.js -o build/index.wasm",
     "gen-metadata": "get-api-metadata shipping-methods build/metadata.json",
     "test": "tsc --noEmit && jest"
   },

--- a/checkout/typescript/shipping-methods/rename-first-shipping-method/package.json
+++ b/checkout/typescript/shipping-methods/rename-first-shipping-method/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "compile": "tsc",
     "prebuild": "webpack",
-    "build": "javy build/index.js -o build/index.wasm",
+    "build": "shopify script javy build/index.js -o build/index.wasm",
     "gen-metadata": "get-api-metadata shipping-methods build/metadata.json",
     "test": "tsc --noEmit && jest"
   },

--- a/checkout/typescript/shipping-methods/sort-shipping-methods/package.json
+++ b/checkout/typescript/shipping-methods/sort-shipping-methods/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "compile": "tsc",
     "prebuild": "webpack",
-    "build": "javy build/index.js -o build/index.wasm",
+    "build": "shopify script javy build/index.js -o build/index.wasm",
     "gen-metadata": "get-api-metadata shipping-methods build/metadata.json",
     "test": "tsc --noEmit && jest"
   },


### PR DESCRIPTION
Closes https://github.com/Shopify/script-service/issues/3718
Copy over changes from https://github.com/Shopify/scripts-apis/pull/462

This should not be merged until a new release of the CLI is published.