### PR TITLE
Revert "Update example scripts to use javy via the shopify-cli command"

### DIFF
--- a/checkout/typescript/payment-methods/default/package.json
+++ b/checkout/typescript/payment-methods/default/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "compile": "tsc",
     "prebuild": "webpack",
-    "build": "shopify script javy build/index.js -o build/index.wasm",
+    "build": "javy build/index.js -o build/index.wasm",
     "gen-metadata": "get-api-metadata payment-methods build/metadata.json",
     "test": "tsc --noEmit && jest"
   },

--- a/checkout/typescript/payment-methods/filter-payment-methods-based-on-configuration/package.json
+++ b/checkout/typescript/payment-methods/filter-payment-methods-based-on-configuration/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "compile": "tsc",
     "prebuild": "webpack",
-    "build": "shopify script javy build/index.js -o build/index.wasm",
+    "build": "javy build/index.js -o build/index.wasm",
     "test": "tsc --noEmit && jest",
     "gen-metadata": "get-api-metadata payment-methods build/metadata.json"
   },

--- a/checkout/typescript/payment-methods/rename-first-payment-method/package.json
+++ b/checkout/typescript/payment-methods/rename-first-payment-method/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "compile": "tsc",
     "prebuild": "webpack",
-    "build": "shopify script javy build/index.js -o build/index.wasm",
+    "build": "javy build/index.js -o build/index.wasm",
     "gen-metadata": "get-api-metadata payment-methods build/metadata.json",
     "test": "tsc --noEmit && jest"
   },

--- a/checkout/typescript/payment-methods/rename-payment-method-on-configuration/package.json
+++ b/checkout/typescript/payment-methods/rename-payment-method-on-configuration/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "compile": "tsc",
     "prebuild": "webpack",
-    "build": "shopify script javy build/index.js -o build/index.wasm",
+    "build": "javy build/index.js -o build/index.wasm",
     "gen-metadata": "get-api-metadata payment-methods build/metadata.json",
     "test": "tsc --noEmit && jest"
   },

--- a/checkout/typescript/payment-methods/sort-payment-methods/package.json
+++ b/checkout/typescript/payment-methods/sort-payment-methods/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "compile": "tsc",
     "prebuild": "webpack",
-    "build": "shopify script javy build/index.js -o build/index.wasm",
+    "build": "javy build/index.js -o build/index.wasm",
     "gen-metadata": "get-api-metadata payment-methods build/metadata.json",
     "test": "tsc --noEmit && jest"
   },

--- a/checkout/typescript/shipping-methods/append-messages-to-shipping-options-based-on-configuration/package.json
+++ b/checkout/typescript/shipping-methods/append-messages-to-shipping-options-based-on-configuration/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "compile": "tsc",
     "prebuild": "webpack",
-    "build": "shopify script javy build/index.js -o build/index.wasm",
+    "build": "javy build/index.js -o build/index.wasm",
     "gen-metadata": "get-api-metadata shipping-methods build/metadata.json",
     "test": "tsc --noEmit && jest"
   },

--- a/checkout/typescript/shipping-methods/default/package.json
+++ b/checkout/typescript/shipping-methods/default/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "compile": "tsc",
     "prebuild": "webpack",
-    "build": "shopify script javy build/index.js -o build/index.wasm",
+    "build": "javy build/index.js -o build/index.wasm",
     "gen-metadata": "get-api-metadata shipping-methods build/metadata.json",
     "test": "tsc --noEmit && jest"
   },

--- a/checkout/typescript/shipping-methods/filter-shipping-methods-based-on-configuration/package.json
+++ b/checkout/typescript/shipping-methods/filter-shipping-methods-based-on-configuration/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "compile": "tsc",
     "prebuild": "webpack",
-    "build": "shopify script javy build/index.js -o build/index.wasm",
+    "build": "javy build/index.js -o build/index.wasm",
     "gen-metadata": "get-api-metadata shipping-methods build/metadata.json",
     "test": "tsc --noEmit && jest"
   },

--- a/checkout/typescript/shipping-methods/rename-first-shipping-method/package.json
+++ b/checkout/typescript/shipping-methods/rename-first-shipping-method/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "compile": "tsc",
     "prebuild": "webpack",
-    "build": "shopify script javy build/index.js -o build/index.wasm",
+    "build": "javy build/index.js -o build/index.wasm",
     "gen-metadata": "get-api-metadata shipping-methods build/metadata.json",
     "test": "tsc --noEmit && jest"
   },

--- a/checkout/typescript/shipping-methods/sort-shipping-methods/package.json
+++ b/checkout/typescript/shipping-methods/sort-shipping-methods/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "compile": "tsc",
     "prebuild": "webpack",
-    "build": "shopify script javy build/index.js -o build/index.wasm",
+    "build": "javy build/index.js -o build/index.wasm",
     "gen-metadata": "get-api-metadata shipping-methods build/metadata.json",
     "test": "tsc --noEmit && jest"
   },


### PR DESCRIPTION
Reverts Shopify/scripts-apis-examples#15

There is a guard clause in the CLI to ensure that only build commands starting with `javy` are valid https://github.com/Shopify/shopify-cli/blob/abd0017b8eb63d8315f8318b2702d498e2b68e2d/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb#L104-L106.

The current plan is to fix that and then wait until the next CLI release before updating these build commands.