### PR TITLE
Bump checkout apis library version to 2.1.0

### DIFF
--- a/checkout/typescript/payment-methods/default/package.json
+++ b/checkout/typescript/payment-methods/default/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@shopify/scripts-checkout-apis": "2.0.0"
+    "@shopify/scripts-checkout-apis": "2.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.15.4",

--- a/checkout/typescript/payment-methods/filter-payment-methods-based-on-configuration/package.json
+++ b/checkout/typescript/payment-methods/filter-payment-methods-based-on-configuration/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@shopify/scripts-checkout-apis": "2.0.0"
+    "@shopify/scripts-checkout-apis": "2.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.15.4",

--- a/checkout/typescript/payment-methods/rename-first-payment-method/package.json
+++ b/checkout/typescript/payment-methods/rename-first-payment-method/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@shopify/scripts-checkout-apis": "2.0.0"
+    "@shopify/scripts-checkout-apis": "2.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.15.4",

--- a/checkout/typescript/payment-methods/rename-payment-method-on-configuration/package.json
+++ b/checkout/typescript/payment-methods/rename-payment-method-on-configuration/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@shopify/scripts-checkout-apis": "2.0.0"
+    "@shopify/scripts-checkout-apis": "2.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.15.4",

--- a/checkout/typescript/payment-methods/sort-payment-methods/package.json
+++ b/checkout/typescript/payment-methods/sort-payment-methods/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@shopify/scripts-checkout-apis": "2.0.0"
+    "@shopify/scripts-checkout-apis": "2.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.15.4",

--- a/checkout/typescript/shipping-methods/append-messages-to-shipping-options-based-on-configuration/package.json
+++ b/checkout/typescript/shipping-methods/append-messages-to-shipping-options-based-on-configuration/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@shopify/scripts-checkout-apis": "2.0.0"
+    "@shopify/scripts-checkout-apis": "2.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.15.4",

--- a/checkout/typescript/shipping-methods/default/package.json
+++ b/checkout/typescript/shipping-methods/default/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@shopify/scripts-checkout-apis": "2.0.0"
+    "@shopify/scripts-checkout-apis": "2.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.15.4",

--- a/checkout/typescript/shipping-methods/filter-shipping-methods-based-on-configuration/package.json
+++ b/checkout/typescript/shipping-methods/filter-shipping-methods-based-on-configuration/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@shopify/scripts-checkout-apis": "2.0.0"
+    "@shopify/scripts-checkout-apis": "2.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.15.4",

--- a/checkout/typescript/shipping-methods/rename-first-shipping-method/package.json
+++ b/checkout/typescript/shipping-methods/rename-first-shipping-method/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@shopify/scripts-checkout-apis": "2.0.0"
+    "@shopify/scripts-checkout-apis": "2.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.15.4",

--- a/checkout/typescript/shipping-methods/sort-shipping-methods/package.json
+++ b/checkout/typescript/shipping-methods/sort-shipping-methods/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@shopify/scripts-checkout-apis": "2.0.0"
+    "@shopify/scripts-checkout-apis": "2.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.15.4",


### PR DESCRIPTION
Bump example scripts to the new 2.1.0 version https://github.com/Shopify/scripts-apis/releases/tag/%40shopify%2Fscripts-checkout-apis%402.1.0