### PR TITLE
Remove usage of console.log*

### DIFF
--- a/discounts/typescript/delivery-discount-types/default/src/index.ts
+++ b/discounts/typescript/delivery-discount-types/default/src/index.ts
@@ -4,7 +4,6 @@ type Payload = DeliveryDiscountTypesAPI.Payload;
 type Output = DeliveryDiscountTypesAPI.Output;
 
 export const main = ({input, configuration}: Payload): Output => {
-  console.log('[Delivery Demo]', configuration);
   const percentage = configuration.value ? parseFloat(configuration.value) : 100;
   const title = configuration.title ?? (percentage === 100 ? 'Free shipping' : `${percentage}% off`);
   return {

--- a/discounts/typescript/merchandise-discount-types/default/src/index.ts
+++ b/discounts/typescript/merchandise-discount-types/default/src/index.ts
@@ -4,7 +4,6 @@ type Payload = MerchandiseDiscountTypesAPI.Payload;
 type Output = MerchandiseDiscountTypesAPI.Output;
 
 export const main = ({input, configuration}: Payload): Output => {
-  console.log('[Merchandise Demo]', configuration);
   const percentage = configuration.value ? parseFloat(configuration.value) : 100;
   return {
     discounts: [


### PR DESCRIPTION
During the pairing session with Jaskson on executing merchandise
discount script into `RuntimeEngineClient::InvalidMsgpackError`. We
found that the Engine output is not in valid msgpack format. Trying to
read the raw output, we saw a weird string `Merchandising Demo`. This
led to our realization that `console.log` is not working properly.
Currently, the STDOUT of the script is captured as the result, and the
STDERR is captured as the logging. When `console.log` writes logging, it
goes to STDOUT and messes up with the normal script result, which ends
up being an invalid msgpack value.

We've reported the bug to wasm-foundation team and an ongoing disuccsion
is at https://shopify.slack.com/archives/C027CG3KQ23/p1646248029092269

At the curent stage, there is no proper way to log in scripts. So I
removed the logging in these two demo scripts. We can add it back when
it's correctly supported.