### PR TITLE
Update default payment methods Rust script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+**/target/
+*.wasm
+.env

--- a/checkout/rust/payment-methods/default/.shopify-cli.yml
+++ b/checkout/rust/payment-methods/default/.shopify-cli.yml
@@ -3,5 +3,5 @@ project_type: :script
 organization_id: 0
 extension_point_type: payment_methods
 title: Default Payment Methods Script
-description: 
+description: Template script that does nothing
 language: rust

--- a/checkout/rust/payment-methods/default/.shopify-cli.yml
+++ b/checkout/rust/payment-methods/default/.shopify-cli.yml
@@ -1,0 +1,7 @@
+---
+project_type: :script
+organization_id: 0
+extension_point_type: payment_methods
+title: Default Payment Methods Script
+description: 
+language: rust

--- a/checkout/rust/payment-methods/default/Cargo.lock
+++ b/checkout/rust/payment-methods/default/Cargo.lock
@@ -15,7 +15,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
-name = "checkout_payment_method_script_rs-script"
+name = "default_payment_method_script"
 version = "1.0.0"
 dependencies = [
  "rmp-serde",

--- a/checkout/rust/payment-methods/default/Cargo.toml
+++ b/checkout/rust/payment-methods/default/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "default_payment_method_script"
 version = "1.0.0"
-edition = "2022"
+edition = "2021"
 
 [dependencies]
 rmp-serde = "0.15.5"

--- a/checkout/rust/payment-methods/default/Makefile
+++ b/checkout/rust/payment-methods/default/Makefile
@@ -1,0 +1,3 @@
+build_wasm:
+	cargo build --release --target "wasm32-wasi" && \
+	cp target/wasm32-wasi/release/*.wasm build/index.wasm

--- a/checkout/rust/payment-methods/default/metadata.json
+++ b/checkout/rust/payment-methods/default/metadata.json
@@ -1,0 +1,1 @@
+{"schemaVersions":{"payment_methods":{"major":1,"minor":0}},"flags":{"use_msgpack":true}}


### PR DESCRIPTION
In conjunction with https://github.com/Shopify/shopify-cli/pull/2253, we'll be able to bootstrap new Rust scripts on the CLI. This will make developing for these APIs much easier than starting with the "wasm" template that doesn't include any code.

These examples are going to be in the docs as well, so we may as well make them accessible to the CLI.