### PR TITLE
Revert "Removing the test workflow"

### DIFF
--- a/.github/workflows/payment-methods.rust.default.yml
+++ b/.github/workflows/payment-methods.rust.default.yml
@@ -1,0 +1,30 @@
+name: Rust
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - "checkout/rust/payment-methods/default/**"
+  pull_request:
+    branches: [ master ]
+    paths:
+      - "checkout/rust/payment-methods/default/**"
+
+env:
+  CARGO_TERM_COLOR: always
+  
+defaults:
+  run:
+    working-directory: "checkout/rust/payment-methods/default"
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose


### PR DESCRIPTION
Reverts Shopify/scripts-apis-examples#33

This PR is a revert because I needed to merge the workflow to test it.

Issue: https://github.com/Shopify/script-service/issues/4661

This workflowspecifically tests out the default rust payment methods script, which only runs if that particular template has changed.

Since this repository is just a collection of self contained templates for copying, having a separate CI process for each script that only runs when relevant code changes seems appropriate.

Any thoughts/concerns on this approach and on alternatives we could follow?