### PR TITLE
Add default toml files to each extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 **/target/
 *.wasm
 .env
+.DS_Store

--- a/checkout/rust/payment-methods/default/shopify.function.toml
+++ b/checkout/rust/payment-methods/default/shopify.function.toml
@@ -1,0 +1,3 @@
+name = "{{name}}"
+type = "{{extensionType}}"
+title = "{{name}}"

--- a/checkout/rust/shipping-methods/default/shopify.function.toml
+++ b/checkout/rust/shipping-methods/default/shopify.function.toml
@@ -1,0 +1,3 @@
+name = "{{name}}"
+type = "{{extensionType}}"
+title = "{{name}}"

--- a/checkout/rust/shipping-rate-presenter/default/shopify.function.toml
+++ b/checkout/rust/shipping-rate-presenter/default/shopify.function.toml
@@ -1,0 +1,3 @@
+name = "{{name}}"
+type = "{{extensionType}}"
+title = "{{name}}"

--- a/checkout/typescript/payment-methods/default/shopify.function.toml
+++ b/checkout/typescript/payment-methods/default/shopify.function.toml
@@ -1,0 +1,3 @@
+name = "{{name}}"
+type = "{{extensionType}}"
+title = "{{name}}"

--- a/checkout/typescript/shipping-methods/default/shopify.function.toml
+++ b/checkout/typescript/shipping-methods/default/shopify.function.toml
@@ -1,0 +1,3 @@
+name = "{{name}}"
+type = "{{extensionType}}"
+title = "{{name}}"

--- a/checkout/wasm/payment-methods/default/shopify.function.toml
+++ b/checkout/wasm/payment-methods/default/shopify.function.toml
@@ -1,0 +1,3 @@
+name = "{{name}}"
+type = "{{extensionType}}"
+title = "{{name}}"

--- a/checkout/wasm/shipping-methods/default/shopify.function.toml
+++ b/checkout/wasm/shipping-methods/default/shopify.function.toml
@@ -1,0 +1,3 @@
+name = "{{name}}"
+type = "{{extensionType}}"
+title = "{{name}}"

--- a/checkout/wasm/shipping-rate-presenter/default/shopify.function.toml
+++ b/checkout/wasm/shipping-rate-presenter/default/shopify.function.toml
@@ -1,0 +1,3 @@
+name = "{{name}}"
+type = "{{extensionType}}"
+title = "{{name}}"

--- a/discounts/rust/merchandise-discount-types/default/shopify.function.toml
+++ b/discounts/rust/merchandise-discount-types/default/shopify.function.toml
@@ -1,0 +1,3 @@
+name = "{{name}}"
+type = "{{extensionType}}"
+title = "{{name}}"

--- a/discounts/wasm/delivery-discount-types/default/shopify.function.toml
+++ b/discounts/wasm/delivery-discount-types/default/shopify.function.toml
@@ -1,0 +1,3 @@
+name = "{{name}}"
+type = "{{extensionType}}"
+title = "{{name}}"

--- a/discounts/wasm/merchandise-discount-types/default/shopify.function.toml
+++ b/discounts/wasm/merchandise-discount-types/default/shopify.function.toml
@@ -1,0 +1,3 @@
+name = "{{name}}"
+type = "{{extensionType}}"
+title = "{{name}}"

--- a/discounts/wasm/order-discount-type/default/shopify.function.toml
+++ b/discounts/wasm/order-discount-type/default/shopify.function.toml
@@ -1,0 +1,3 @@
+name = "{{name}}"
+type = "{{extensionType}}"
+title = "{{name}}"

--- a/discounts/wasm/product-discount-type/default/shopify.function.toml
+++ b/discounts/wasm/product-discount-type/default/shopify.function.toml
@@ -1,0 +1,3 @@
+name = "{{name}}"
+type = "{{extensionType}}"
+title = "{{name}}"

--- a/discounts/wasm/shipping-discount-type/default/shopify.function.toml
+++ b/discounts/wasm/shipping-discount-type/default/shopify.function.toml
@@ -1,0 +1,3 @@
+name = "{{name}}"
+type = "{{extensionType}}"
+title = "{{name}}"


### PR DESCRIPTION
Following the Functions acceptance criteria, each function needs to have a `shopify.function.toml` file that includes details for that specific function.

Since the contents of this toml will depend on the language, extension type and maybe other factors it makes sense that it is included by default in the template and not generated automatically by the CLI.

Any value wrote in templating format: `{{variable}}` will be replaced during scaffolding and If the `.toml` file is missing scaffolding will fail.

I added a `.toml` file to each `default` folder, let me know if i'm missing anything!