### PR TITLE
Add default wasm templates for renamed discounts APIs

### DIFF
--- a/discounts/wasm/order-discounts/default/input.graphql
+++ b/discounts/wasm/order-discounts/default/input.graphql
@@ -1,0 +1,4 @@
+{
+  # select fields on MerchandiseDiscountRoot
+  # or delete this file if the script requires no input
+}

--- a/discounts/wasm/order-discounts/default/metadata.json
+++ b/discounts/wasm/order-discounts/default/metadata.json
@@ -1,0 +1,1 @@
+{"schemaVersions":{"order_discounts":{"major":1,"minor":0}},"flags":{"use_msgpack":true}}

--- a/discounts/wasm/order-discounts/default/schema.graphql
+++ b/discounts/wasm/order-discounts/default/schema.graphql
@@ -1,0 +1,166 @@
+schema {
+  query: MerchandiseDiscountRoot
+}
+
+type Address {
+  city: String
+  countryCode: String
+  phone: String
+  poBox: Boolean!
+  provinceCode: String
+  zip: String
+}
+
+type Customer implements HasMetafields {
+  acceptsMarketing: Boolean
+  email: String
+  id: UnsignedInt64!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+  orderCount: Int
+  phone: String
+  tags: [String!]
+  totalSpent: Money
+}
+
+type DeliveryLine {
+  destination: Address
+  index: Int
+  subscription: Boolean
+}
+
+interface HasMetafields {
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+}
+
+"""
+A [JSON](https://www.json.org/json-en.html) object.
+
+Example value:
+`{
+  "product": {
+    "id": "gid://shopify/Product/1346443542550",
+    "title": "White T-shirt",
+    "options": [{
+      "name": "Size",
+      "values": ["M", "L"]
+    }]
+  }
+}`
+"""
+scalar JSON
+
+type MerchandiseDiscountRoot {
+  customer: Customer
+  deliveryLines: [DeliveryLine!]
+  locale: String
+  merchandiseLines: [MerchandiseLine!]
+}
+
+type MerchandiseLine {
+  index: Int
+  price: Money!
+  properties: [Property!]
+  quantity: Int
+  sellingPlan: SellingPlan
+  variant: Variant
+  weight: Int
+}
+
+type Metafield {
+  type: String!
+  value: JSON!
+}
+
+type Money {
+  currency: String!
+  subunits: UnsignedInt64!
+}
+
+type Product implements HasMetafields {
+  giftCard: Boolean
+  id: UnsignedInt64!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+  tags: [String!]
+  title: String
+  type: String
+  vendor: String
+}
+
+type Property {
+  key: String!
+  value: String!
+}
+
+type SellingPlan {
+  id: UnsignedInt64!
+}
+
+"""
+Unsigned integer of up to 64 bit, encoded as a number (not a string).
+Example value: `1099511627776`
+"""
+scalar UnsignedInt64
+
+type Variant implements HasMetafields {
+  compareAtPrice: Money
+  id: UnsignedInt64!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+  product: Product
+  sku: String
+  title: String
+}

--- a/discounts/wasm/order-discounts/default/script.config.yml
+++ b/discounts/wasm/order-discounts/default/script.config.yml
@@ -1,0 +1,5 @@
+---
+version: 2
+configuration:
+  type: object
+  fields: {}

--- a/discounts/wasm/product-discounts/default/input.graphql
+++ b/discounts/wasm/product-discounts/default/input.graphql
@@ -1,0 +1,4 @@
+{
+  # select fields on MerchandiseDiscountRoot
+  # or delete this file if the script requires no input
+}

--- a/discounts/wasm/product-discounts/default/metadata.json
+++ b/discounts/wasm/product-discounts/default/metadata.json
@@ -1,0 +1,1 @@
+{"schemaVersions":{"product_discounts":{"major":1,"minor":0}},"flags":{"use_msgpack":true}}

--- a/discounts/wasm/product-discounts/default/schema.graphql
+++ b/discounts/wasm/product-discounts/default/schema.graphql
@@ -1,0 +1,166 @@
+schema {
+  query: MerchandiseDiscountRoot
+}
+
+type Address {
+  city: String
+  countryCode: String
+  phone: String
+  poBox: Boolean!
+  provinceCode: String
+  zip: String
+}
+
+type Customer implements HasMetafields {
+  acceptsMarketing: Boolean
+  email: String
+  id: UnsignedInt64!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+  orderCount: Int
+  phone: String
+  tags: [String!]
+  totalSpent: Money
+}
+
+type DeliveryLine {
+  destination: Address
+  index: Int
+  subscription: Boolean
+}
+
+interface HasMetafields {
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+}
+
+"""
+A [JSON](https://www.json.org/json-en.html) object.
+
+Example value:
+`{
+  "product": {
+    "id": "gid://shopify/Product/1346443542550",
+    "title": "White T-shirt",
+    "options": [{
+      "name": "Size",
+      "values": ["M", "L"]
+    }]
+  }
+}`
+"""
+scalar JSON
+
+type MerchandiseDiscountRoot {
+  customer: Customer
+  deliveryLines: [DeliveryLine!]
+  locale: String
+  merchandiseLines: [MerchandiseLine!]
+}
+
+type MerchandiseLine {
+  index: Int
+  price: Money!
+  properties: [Property!]
+  quantity: Int
+  sellingPlan: SellingPlan
+  variant: Variant
+  weight: Int
+}
+
+type Metafield {
+  type: String!
+  value: JSON!
+}
+
+type Money {
+  currency: String!
+  subunits: UnsignedInt64!
+}
+
+type Product implements HasMetafields {
+  giftCard: Boolean
+  id: UnsignedInt64!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+  tags: [String!]
+  title: String
+  type: String
+  vendor: String
+}
+
+type Property {
+  key: String!
+  value: String!
+}
+
+type SellingPlan {
+  id: UnsignedInt64!
+}
+
+"""
+Unsigned integer of up to 64 bit, encoded as a number (not a string).
+Example value: `1099511627776`
+"""
+scalar UnsignedInt64
+
+type Variant implements HasMetafields {
+  compareAtPrice: Money
+  id: UnsignedInt64!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+  product: Product
+  sku: String
+  title: String
+}

--- a/discounts/wasm/product-discounts/default/script.config.yml
+++ b/discounts/wasm/product-discounts/default/script.config.yml
@@ -1,0 +1,5 @@
+---
+version: 2
+configuration:
+  type: object
+  fields: {}

--- a/discounts/wasm/shipping-discounts/default/input.graphql
+++ b/discounts/wasm/shipping-discounts/default/input.graphql
@@ -1,0 +1,4 @@
+{
+  # select fields on DeliveryDiscountRoot
+  # or delete this file if the script requires no input
+}

--- a/discounts/wasm/shipping-discounts/default/metadata.json
+++ b/discounts/wasm/shipping-discounts/default/metadata.json
@@ -1,0 +1,1 @@
+{"schemaVersions":{"shipping_discounts":{"major":1,"minor":0}},"flags":{"use_msgpack":true}}

--- a/discounts/wasm/shipping-discounts/default/schema.graphql
+++ b/discounts/wasm/shipping-discounts/default/schema.graphql
@@ -1,0 +1,174 @@
+schema {
+  query: DeliveryDiscountRoot
+}
+
+type Address {
+  city: String
+  countryCode: String
+  phone: String
+  poBox: Boolean!
+  provinceCode: String
+  zip: String
+}
+
+type Customer implements HasMetafields {
+  acceptsMarketing: Boolean
+  email: String
+  id: UnsignedInt64!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+  orderCount: Int
+  phone: String
+  tags: [String!]
+  totalSpent: Money
+}
+
+type DeliveryDiscountRoot {
+  customer: Customer
+  deliveryLines: [DeliveryLineWithStrategy!]
+  locale: String
+  merchandiseLines: [MerchandiseLine!]
+}
+
+type DeliveryLineWithStrategy {
+  destination: Address
+  index: Int
+  price: Money!
+  strategy: DeliveryStrategy!
+  subscription: Boolean
+}
+
+type DeliveryStrategy {
+  code: String
+  name: String
+  source: String
+}
+
+interface HasMetafields {
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+}
+
+"""
+A [JSON](https://www.json.org/json-en.html) object.
+
+Example value:
+`{
+  "product": {
+    "id": "gid://shopify/Product/1346443542550",
+    "title": "White T-shirt",
+    "options": [{
+      "name": "Size",
+      "values": ["M", "L"]
+    }]
+  }
+}`
+"""
+scalar JSON
+
+type MerchandiseLine {
+  index: Int
+  price: Money!
+  properties: [Property!]
+  quantity: Int
+  sellingPlan: SellingPlan
+  variant: Variant
+  weight: Int
+}
+
+type Metafield {
+  type: String!
+  value: JSON!
+}
+
+type Money {
+  currency: String!
+  subunits: UnsignedInt64!
+}
+
+type Product implements HasMetafields {
+  giftCard: Boolean
+  id: UnsignedInt64!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+  tags: [String!]
+  title: String
+  type: String
+  vendor: String
+}
+
+type Property {
+  key: String!
+  value: String!
+}
+
+type SellingPlan {
+  id: UnsignedInt64!
+}
+
+"""
+Unsigned integer of up to 64 bit, encoded as a number (not a string).
+Example value: `1099511627776`
+"""
+scalar UnsignedInt64
+
+type Variant implements HasMetafields {
+  compareAtPrice: Money
+  id: UnsignedInt64!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+  product: Product
+  sku: String
+  title: String
+}

--- a/discounts/wasm/shipping-discounts/default/script.config.yml
+++ b/discounts/wasm/shipping-discounts/default/script.config.yml
@@ -1,0 +1,5 @@
+---
+version: 2
+configuration:
+  type: object
+  fields: {}


### PR DESCRIPTION
#gsd:23145

Add new wasm default templates as part of rename:

- `product_discount_type` -> `product_discounts`
- `order_discount_type` -> `order_discounts`
- `shipping_discount_type` -> `shipping_discounts`