### PR TITLE
Use wasm-opt to reduce size of default shipping script wasmf rom 488k -> 130k

### DIFF
--- a/checkout/rust/shipping-methods/default/Makefile
+++ b/checkout/rust/shipping-methods/default/Makefile
@@ -1,4 +1,4 @@
 build_wasm:
 	mkdir -p build/ && \
 	cargo build --release --target "wasm32-wasi" && \
-	cp target/wasm32-wasi/release/*.wasm build/index.wasm
+	wasm-opt -O3 --strip-debug target/wasm32-wasi/release/*.wasm -o \build/index.wasm


### PR DESCRIPTION
We only allow <256kb module size on our platform now.

You can get `wasm-opt` with `brew install binaryen`