### PR TITLE
[Discounts] Add default demo functions for new discounts APIs

### DIFF
--- a/discounts/rust/order-discounts/default/.gitignore
+++ b/discounts/rust/order-discounts/default/.gitignore
@@ -1,0 +1,3 @@
+/target
+/build
+Cargo.lock

--- a/discounts/rust/order-discounts/default/Cargo.toml
+++ b/discounts/rust/order-discounts/default/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "order_discounts"
+version = "1.0.0"
+edition = "2021"
+include = ["*.graphql"]
+
+[dependencies]
+serde = { version = "1.0.13", features = ["derive"] }
+serde_with = "1.13.0"
+serde_json = "1.0"
+graphql_client = "0.10.0"
+
+[profile.release]
+lto = true
+opt-level = 's'
+strip = true

--- a/discounts/rust/order-discounts/default/Cargo.toml
+++ b/discounts/rust/order-discounts/default/Cargo.toml
@@ -8,7 +8,6 @@ include = ["*.graphql"]
 serde = { version = "1.0.13", features = ["derive"] }
 serde_with = "1.13.0"
 serde_json = "1.0"
-graphql_client = "0.10.0"
 
 [profile.release]
 lto = true

--- a/discounts/rust/order-discounts/default/Makefile
+++ b/discounts/rust/order-discounts/default/Makefile
@@ -1,0 +1,4 @@
+build_wasm:
+	mkdir -p build/ && \
+	cargo build --release --target "wasm32-wasi" && \
+	wasm-opt -O3 --strip-debug target/wasm32-wasi/release/*.wasm -o ./build/index.wasm

--- a/discounts/rust/order-discounts/default/Makefile
+++ b/discounts/rust/order-discounts/default/Makefile
@@ -1,4 +1,4 @@
 build_wasm:
 	mkdir -p build/ && \
 	cargo build --release --target "wasm32-wasi" && \
-	wasm-opt -O3 --strip-debug target/wasm32-wasi/release/*.wasm -o ./build/index.wasm
+	wasm-opt -Oz --strip-debug target/wasm32-wasi/release/*.wasm -o ./build/index.wasm

--- a/discounts/rust/order-discounts/default/README.md
+++ b/discounts/rust/order-discounts/default/README.md
@@ -1,0 +1,11 @@
+### Prerequisites
+
+* [Install Rust](https://www.rust-lang.org/tools/install)
+* Add `wasm32-wasi` target: `rustup target add wasm32-wasi`
+* Install `wasm-opt`: `brew install binaryen`
+
+### Build
+
+```
+make
+```

--- a/discounts/rust/order-discounts/default/README.md
+++ b/discounts/rust/order-discounts/default/README.md
@@ -1,11 +1,19 @@
-### Prerequisites
+## Dependencies
 
-* [Install Rust](https://www.rust-lang.org/tools/install)
-* Add `wasm32-wasi` target: `rustup target add wasm32-wasi`
-* Install `wasm-opt`: `brew install binaryen`
+### Rust
 
-### Build
+[Install Rust](https://www.rust-lang.org/tools/install)
 
-```
+Ensure you have the Wasm build target installed with `rustup show`. You should see `wasm32-wasi` as
+a build target. If not, install the build target via `rustup target add wasm32-wasi`.
+
+### `wasm-opt`
+Wasm-opt is part of binaryen. The easiest way to install binaryen on MacOS is `brew install binaryen` or you can download your OS-specific binary on the [release page](https://github.com/WebAssembly/binaryen/releases).
+
+## Building the script
+
+This builds the rust package to Wasm as `build/index.wasm` and strips it from its debug symbols.
+
+```sh
 make
 ```

--- a/discounts/rust/order-discounts/default/handle-result.graphql
+++ b/discounts/rust/order-discounts/default/handle-result.graphql
@@ -1,3 +1,0 @@
-mutation HandleResult($result: FunctionResult!) {
-  handleResult(result: $result)
-}

--- a/discounts/rust/order-discounts/default/handle-result.graphql
+++ b/discounts/rust/order-discounts/default/handle-result.graphql
@@ -1,0 +1,3 @@
+mutation HandleResult($result: FunctionResult!) {
+  handleResult(result: $result)
+}

--- a/discounts/rust/order-discounts/default/metadata.json
+++ b/discounts/rust/order-discounts/default/metadata.json
@@ -1,0 +1,1 @@
+{"schemaVersions":{"order_discounts":{"major":1,"minor":0}},"flags":{"use_msgpack":true}}

--- a/discounts/rust/order-discounts/default/schema.graphql
+++ b/discounts/rust/order-discounts/default/schema.graphql
@@ -1,0 +1,276 @@
+schema {
+  query: Input
+  mutation: MutationRoot
+}
+
+"""
+Exactly one field of input must be provided, and all others omitted.
+"""
+directive @oneOf on INPUT_OBJECT
+
+type Address {
+  city: String
+  countryCode: String
+  phone: String
+  poBox: Boolean!
+  provinceCode: String
+  zip: String
+}
+
+input Condition @oneOf {
+  orderMinimumSubtotal: OrderMinimumSubtotal
+  productMinimumQuantity: ProductMinimumQuantity
+  productMinimumSubtotal: ProductMinimumSubtotal
+}
+
+type Customer implements HasMetafields {
+  acceptsMarketing: Boolean
+  email: String
+  id: ID
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+  orderCount: Int
+  phone: String
+  tags: [String!]
+  totalSpent: Money
+}
+
+type DeliveryLine {
+  destination: Address
+  id: ID
+  subscription: Boolean
+}
+
+input Discount {
+  conditions: [Condition!]
+  message: String
+  targets: [Target!]!
+  value: Value!
+}
+
+enum DiscountApplicationStrategy {
+  FIRST
+  MAXIMUM
+}
+
+input FixedAmount {
+  value: Float!
+}
+
+interface HasMetafields {
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+}
+
+"""
+Represents a unique identifier that is Base64 obfuscated. It is often used to
+refetch an object or as key for a cache. The ID type appears in a JSON response
+as a String; however, it is not intended to be human-readable. When expected as
+an input type, any string (such as `"VXNlci0xMA=="`) or integer (such as `4`)
+input value will be accepted as an ID.
+"""
+scalar ID
+
+type Input {
+  customer: Customer
+  deliveryLines: [DeliveryLine!]
+  locale: String
+  merchandiseLines: [MerchandiseLine!]
+}
+
+"""
+A [JSON](https://www.json.org/json-en.html) object.
+Example value:
+`{
+  "product": {
+    "id": "gid://shopify/Product/1346443542550",
+    "title": "White T-shirt",
+    "options": [{
+      "name": "Size",
+      "values": ["M", "L"]
+    }]
+  }
+}`
+"""
+scalar JSON
+
+type MerchandiseLine {
+  id: ID
+  price: Money!
+  properties: [Property!]
+  quantity: Int
+  sellingPlan: SellingPlan
+  variant: Variant
+  weight: Int
+}
+
+type Metafield {
+  type: String!
+  value: JSON!
+}
+
+type Money {
+  currency: String!
+  subunits: UnsignedInt64!
+}
+
+"""
+The root mutation for the API.
+"""
+type MutationRoot {
+  """
+  The mutation that defines the structure of a valid result for the function.
+  """
+  handleResult(
+    """
+    The result of the function.
+    """
+    result: Result!
+  ): Void!
+}
+
+input OrderMinimumSubtotal {
+  excludedVariantIds: [ID!]!
+  minimumAmount: Float!
+  targetType: TargetType!
+}
+
+input OrderSubtotalTarget {
+  excludedVariantIds: [ID!]!
+}
+
+input Percentage {
+  value: Float!
+}
+
+type Product implements HasMetafields {
+  giftCard: Boolean
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+  tags: [String!]
+  title: String
+  type: String
+  vendor: String
+}
+
+input ProductMinimumQuantity {
+  ids: [ID!]!
+  minimumQuantity: Int!
+  targetType: TargetType!
+}
+
+input ProductMinimumSubtotal {
+  ids: [ID!]!
+  minimumAmount: Float!
+  targetType: TargetType!
+}
+
+input ProductVariantTarget {
+  id: ID!
+  quantity: Int
+}
+
+type Property {
+  key: String!
+  value: String!
+}
+
+"""
+The result of the function.
+"""
+input FunctionResult {
+  discountApplicationStrategy: DiscountApplicationStrategy!
+  discounts: [Discount!]!
+}
+
+type SellingPlan {
+  id: ID!
+}
+
+input Target @oneOf {
+  orderSubtotal: OrderSubtotalTarget
+  productVariant: ProductVariantTarget
+}
+
+enum TargetType {
+  ORDER_SUBTOTAL
+  PRODUCT_VARIANT
+}
+
+"""
+Unsigned integer of up to 64 bit, encoded as a number (not a string).
+Example value: `1099511627776`
+"""
+scalar UnsignedInt64
+
+input Value @oneOf {
+  fixedAmount: FixedAmount
+  percentage: Percentage
+}
+
+type Variant implements HasMetafields {
+  compareAtPrice: Money
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+  product: Product
+  sku: String
+  title: String
+}
+
+"""
+A void type that can be used to return a null value from a mutation.
+"""
+scalar Void

--- a/discounts/rust/order-discounts/default/schema.graphql
+++ b/discounts/rust/order-discounts/default/schema.graphql
@@ -70,6 +70,14 @@ input FixedAmount {
   value: Float!
 }
 
+"""
+The result of the function.
+"""
+input FunctionResult {
+  discountApplicationStrategy: DiscountApplicationStrategy!
+  discounts: [Discount!]!
+}
+
 interface HasMetafields {
   """
   Returns a metafield by namespace and key that belongs to the resource.
@@ -105,6 +113,7 @@ type Input {
 
 """
 A [JSON](https://www.json.org/json-en.html) object.
+
 Example value:
 `{
   "product": {
@@ -150,7 +159,7 @@ type MutationRoot {
     """
     The result of the function.
     """
-    result: Result!
+    result: FunctionResult!
   ): Void!
 }
 
@@ -212,14 +221,6 @@ input ProductVariantTarget {
 type Property {
   key: String!
   value: String!
-}
-
-"""
-The result of the function.
-"""
-input FunctionResult {
-  discountApplicationStrategy: DiscountApplicationStrategy!
-  discounts: [Discount!]!
 }
 
 type SellingPlan {

--- a/discounts/rust/order-discounts/default/script.config.yml
+++ b/discounts/rust/order-discounts/default/script.config.yml
@@ -1,0 +1,19 @@
+---
+version: '2'
+configuration:
+  type: object
+  fields:
+    value:
+      type: number_decimal
+      name: Percentage off
+      validations:
+      - name: min
+        value: "0"
+      - name: max
+        value: "100"
+    excludedVariantIds:
+      type: array
+      name: Excluded Product Variants
+      elementType:
+        type: variant_reference
+        name: Product Variant

--- a/discounts/rust/order-discounts/default/src/api.rs
+++ b/discounts/rust/order-discounts/default/src/api.rs
@@ -1,0 +1,91 @@
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub struct FunctionResult {
+    pub discounts: Vec<Discount>,
+    pub discount_application_strategy: DiscountApplicationStrategy,
+}
+
+pub type ID = String;
+pub type MoneySubunits = u64;
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Serialize)]
+pub struct Discount {
+    pub value: Value,
+    pub targets: Vec<Target>,
+    pub message: Option<String>,
+    pub conditions: Option<Condition>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub enum Value {
+    FixedAmount(FixedAmount),
+    Percentage(Percentage),
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct FixedAmount {
+    pub value: MoneySubunits,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct Percentage {
+    pub value: f64,
+}
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub enum Target {
+    #[serde(rename_all(serialize = "camelCase"))]
+    OrderSubtotal {
+        excluded_variant_ids: Vec<ID>,
+    },
+    ProductVariant {
+        id: ID,
+        quantity: Option<u64>,
+    },
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub enum Condition {
+    #[serde(rename_all(serialize = "camelCase"))]
+    OrderMinimumSubtotal {
+        target_type: ConditionTargetType,
+        excluded_variant_ids: Vec<ID>,
+        minimum_amount: MoneySubunits,
+    },
+    #[serde(rename_all(serialize = "camelCase"))]
+    ProductMinimumQuantity {
+        target_type: ConditionTargetType,
+        excluded_variant_ids: Vec<ID>,
+        minimum_amount: MoneySubunits,
+    },
+    #[serde(rename_all(serialize = "camelCase"))]
+    ProductMinimumSubtotal {
+        target_type: ConditionTargetType,
+        excluded_variant_ids: Vec<ID>,
+        minimum_amount: MoneySubunits,
+    },
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "SCREAMING_SNAKE_CASE"))]
+pub enum ConditionTargetType {
+    OrderSubtotal,
+    ProductVariant,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "SCREAMING_SNAKE_CASE"))]
+pub enum DiscountApplicationStrategy {
+    First,
+    Maximum,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Input {}

--- a/discounts/rust/order-discounts/default/src/api.rs
+++ b/discounts/rust/order-discounts/default/src/api.rs
@@ -1,4 +1,5 @@
 // Types defined in this file conforms to the schema https://github.com/Shopify/shopify/blob/main/db/graphql/shopify_vm/order_discounts.graphql
+// All input fields are optional as they may not be included in the input query
 #![allow(dead_code)]
 
 pub type Boolean = bool;
@@ -51,7 +52,7 @@ pub mod input {
         pub city: Option<String>,
         pub country_code: Option<String>,
         pub phone: Option<String>,
-        pub po_box: Boolean,
+        pub po_box: Option<Boolean>,
         pub province_code: Option<String>,
         pub zip: Option<String>,
     }
@@ -70,20 +71,20 @@ pub mod input {
 
     #[derive(Clone, Debug, Deserialize)]
     pub struct Properties {
-        pub key: String,
-        pub value: String,
+        pub key: Option<String>,
+        pub value: Option<String>,
     }
 
     #[derive(Clone, Debug, Deserialize)]
     pub struct SellingPlan {
-        pub id: ID,
+        pub id: Option<ID>,
     }
 
     #[derive(Clone, Debug, Deserialize)]
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Variant {
         pub compare_at_price: Option<Money>,
-        pub id: ID,
+        pub id: Option<ID>,
         pub product: Option<Product>,
         pub sku: Option<String>,
         pub title: Option<String>,
@@ -93,7 +94,7 @@ pub mod input {
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Product {
         pub gift_card: Option<Boolean>,
-        pub id: ID,
+        pub id: Option<ID>,
         pub tags: Option<Vec<String>>,
         pub title: Option<String>,
         pub type_: Option<String>,

--- a/discounts/rust/order-discounts/default/src/api.rs
+++ b/discounts/rust/order-discounts/default/src/api.rs
@@ -60,7 +60,7 @@ pub mod input {
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct MerchandiseLine {
         pub id: Option<ID>,
-        pub price: Money,
+        pub price: Option<Money>,
         pub properties: Option<Vec<Properties>>,
         pub quantity: Option<Int>,
         pub selling_plan: Option<SellingPlan>,

--- a/discounts/rust/order-discounts/default/src/main.rs
+++ b/discounts/rust/order-discounts/default/src/main.rs
@@ -1,0 +1,156 @@
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+use graphql_client::GraphQLQuery;
+
+type Void = ();
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "schema.graphql",
+    query_path = "handle-result.graphql",
+    response_derives = "Debug, Clone, PartialEq",
+    normalization = "rust"
+)]
+struct HandleResult;
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Configuration {
+    value: Option<String>,
+    excluded_variant_ids: Option<Vec<String>>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct Input {
+    configuration: Configuration,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let input: Input = serde_json::from_reader(std::io::BufReader::new(std::io::stdin()))?;
+    let mut out = std::io::stdout();
+    let mut serializer = serde_json::Serializer::new(&mut out);
+    script(input)?.serialize(&mut serializer)?;
+    Ok(())
+}
+
+fn script(input: Input) -> Result<handle_result::FunctionResult, Box<dyn std::error::Error>> {
+    const DEFAULT_VALUE: f64 = 50.0;
+
+    let config = input.configuration;
+    let value: f64 = if let Some(value) = config.value {
+        value.parse()?
+    } else {
+        DEFAULT_VALUE
+    };
+    let excluded_variant_ids = &config.excluded_variant_ids.unwrap_or_default();
+    let targets = vec![target(excluded_variant_ids)];
+    Ok(build_result(value, targets))
+}
+
+fn target(excluded_variant_ids: &[String]) -> handle_result::Target {
+    handle_result::Target {
+        orderSubtotal: Some(handle_result::OrderSubtotalTarget {
+            excludedVariantIds: excluded_variant_ids
+                .iter()
+                .filter_map(|gid| gid.split('/').last().map(|id| id.parse().unwrap()))
+                .collect(),
+        }),
+        productVariant: None,
+    }
+}
+
+fn build_result(value: f64, targets: Vec<handle_result::Target>) -> handle_result::FunctionResult {
+    handle_result::FunctionResult {
+        discounts: vec![handle_result::Discount {
+            message: Some(format!("{}% off", value)),
+            conditions: None,
+            targets,
+            value: handle_result::Value {
+                percentage: Some(handle_result::Percentage { value }),
+                fixedAmount: None,
+            },
+        }],
+        discountApplicationStrategy: handle_result::DiscountApplicationStrategy::First,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_discount_with_default_value() {
+        let input = Input {
+            configuration: Configuration {
+                value: None,
+                excluded_variant_ids: None,
+            },
+        };
+        let result = serde_json::json!(script(input).unwrap());
+
+        let expected_json = r#"
+            {
+                "discounts": [{
+                    "message": "50% off",
+                    "targets": [{ "orderSubtotal": { "excludedVariantIds": [] } }],
+                    "value": { "percentage": { "value": 50.0 } }
+                }],
+                "discountApplicationStrategy": "FIRST"
+            }
+        "#;
+
+        let expected_result: serde_json::Value = serde_json::from_str(expected_json).unwrap();
+        assert_eq!(result.to_string(), expected_result.to_string());
+    }
+
+    #[test]
+    fn test_discount_with_value() {
+        let input = Input {
+            configuration: Configuration {
+                value: Some("10".to_string()),
+                excluded_variant_ids: None,
+            },
+        };
+        let result = serde_json::json!(script(input).unwrap());
+
+        let expected_json = r#"
+            {
+                "discounts": [{
+                    "message": "10% off",
+                    "targets": [{ "orderSubtotal": { "excludedVariantIds": [] } }],
+                    "value": { "percentage": { "value": 10.0 } }
+                }],
+                "discountApplicationStrategy": "FIRST"
+            }
+        "#;
+
+        let expected_result: serde_json::Value = serde_json::from_str(expected_json).unwrap();
+        assert_eq!(result.to_string(), expected_result.to_string());
+    }
+
+    #[test]
+    fn test_discount_with_excluded_variant_ids() {
+        let input = Input {
+            configuration: Configuration {
+                value: None,
+                excluded_variant_ids: Some(vec!["gid://shopify/ProductVariant/0".to_string()]),
+            },
+        };
+        let result = serde_json::json!(script(input).unwrap());
+
+        let expected_json = r#"
+            {
+                "discounts": [{
+                    "message": "50% off",
+                    "targets": [{ "orderSubtotal": { "excludedVariantIds": [0] } }],
+                    "value": { "percentage": { "value": 50.0 } }
+                }],
+                "discountApplicationStrategy": "FIRST"
+            }
+        "#;
+
+        let expected_result: serde_json::Value = serde_json::from_str(expected_json).unwrap();
+        assert_eq!(result.to_string(), expected_result.to_string());
+    }
+}

--- a/discounts/rust/order-discounts/default/src/main.rs
+++ b/discounts/rust/order-discounts/default/src/main.rs
@@ -68,14 +68,8 @@ mod tests {
         {
             "input": {
                 "merchandiseLines": [
-                    {
-                        "variant": { "id": "gid://shopify/ProductVariant/0" },
-                        "price": { "currency": "CAD", "subunits": 100 }
-                    },
-                    {
-                        "variant": { "id": "gid://shopify/ProductVariant/1" },
-                        "price": { "currency": "CAD", "subunits": 100 }
-                    }
+                    { "variant": { "id": "gid://shopify/ProductVariant/0" } },
+                    { "variant": { "id": "gid://shopify/ProductVariant/1" } }
                 ]
             },
             "configuration": {

--- a/discounts/rust/product-discounts/default/.gitignore
+++ b/discounts/rust/product-discounts/default/.gitignore
@@ -1,0 +1,3 @@
+/target
+/build
+Cargo.lock

--- a/discounts/rust/product-discounts/default/Cargo.toml
+++ b/discounts/rust/product-discounts/default/Cargo.toml
@@ -6,8 +6,8 @@ include = ["*.graphql"]
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }
+serde_with = "1.13.0"
 serde_json = "1.0"
-graphql_client = "0.10.0"
 
 [profile.release]
 lto = true

--- a/discounts/rust/product-discounts/default/Cargo.toml
+++ b/discounts/rust/product-discounts/default/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "product_discounts"
+version = "1.0.0"
+edition = "2021"
+include = ["*.graphql"]
+
+[dependencies]
+serde = { version = "1.0.13", features = ["derive"] }
+serde_json = "1.0"
+graphql_client = "0.10.0"
+
+[profile.release]
+lto = true
+opt-level = 's'
+strip = true

--- a/discounts/rust/product-discounts/default/Makefile
+++ b/discounts/rust/product-discounts/default/Makefile
@@ -1,0 +1,4 @@
+build_wasm:
+	mkdir -p build/ && \
+	cargo build --release --target "wasm32-wasi" && \
+	wasm-opt -O3 --strip-debug target/wasm32-wasi/release/*.wasm -o ./build/index.wasm

--- a/discounts/rust/product-discounts/default/Makefile
+++ b/discounts/rust/product-discounts/default/Makefile
@@ -1,4 +1,4 @@
 build_wasm:
 	mkdir -p build/ && \
 	cargo build --release --target "wasm32-wasi" && \
-	wasm-opt -O3 --strip-debug target/wasm32-wasi/release/*.wasm -o ./build/index.wasm
+	wasm-opt -Oz --strip-debug target/wasm32-wasi/release/*.wasm -o ./build/index.wasm

--- a/discounts/rust/product-discounts/default/README.md
+++ b/discounts/rust/product-discounts/default/README.md
@@ -1,0 +1,11 @@
+### Prerequisites
+
+* [Install Rust](https://www.rust-lang.org/tools/install)
+* Add `wasm32-wasi` target: `rustup target add wasm32-wasi`
+* Install `wasm-opt`: `brew install binaryen`
+
+### Build
+
+```
+make
+```

--- a/discounts/rust/product-discounts/default/README.md
+++ b/discounts/rust/product-discounts/default/README.md
@@ -1,11 +1,19 @@
-### Prerequisites
+## Dependencies
 
-* [Install Rust](https://www.rust-lang.org/tools/install)
-* Add `wasm32-wasi` target: `rustup target add wasm32-wasi`
-* Install `wasm-opt`: `brew install binaryen`
+### Rust
 
-### Build
+[Install Rust](https://www.rust-lang.org/tools/install)
 
-```
+Ensure you have the Wasm build target installed with `rustup show`. You should see `wasm32-wasi` as
+a build target. If not, install the build target via `rustup target add wasm32-wasi`.
+
+### `wasm-opt`
+Wasm-opt is part of binaryen. The easiest way to install binaryen on MacOS is `brew install binaryen` or you can download your OS-specific binary on the [release page](https://github.com/WebAssembly/binaryen/releases).
+
+## Building the script
+
+This builds the rust package to Wasm as `build/index.wasm` and strips it from its debug symbols.
+
+```sh
 make
 ```

--- a/discounts/rust/product-discounts/default/handle-result.graphql
+++ b/discounts/rust/product-discounts/default/handle-result.graphql
@@ -1,3 +1,0 @@
-mutation HandleResult($result: FunctionResult!) {
-  handleResult(result: $result)
-}

--- a/discounts/rust/product-discounts/default/handle-result.graphql
+++ b/discounts/rust/product-discounts/default/handle-result.graphql
@@ -1,0 +1,3 @@
+mutation HandleResult($result: FunctionResult!) {
+  handleResult(result: $result)
+}

--- a/discounts/rust/product-discounts/default/input.graphql
+++ b/discounts/rust/product-discounts/default/input.graphql
@@ -1,0 +1,7 @@
+query Input {
+  merchandiseLines {
+    variant {
+      id
+    }
+  }
+}

--- a/discounts/rust/product-discounts/default/metadata.json
+++ b/discounts/rust/product-discounts/default/metadata.json
@@ -1,0 +1,1 @@
+{"schemaVersions":{"product_discounts":{"major":1,"minor":0}},"flags":{"use_msgpack":true}}

--- a/discounts/rust/product-discounts/default/schema.graphql
+++ b/discounts/rust/product-discounts/default/schema.graphql
@@ -70,6 +70,14 @@ input FixedAmount {
   value: Float!
 }
 
+"""
+The result of the function.
+"""
+input FunctionResult {
+  discountApplicationStrategy: DiscountApplicationStrategy!
+  discounts: [Discount!]!
+}
+
 interface HasMetafields {
   """
   Returns a metafield by namespace and key that belongs to the resource.
@@ -105,6 +113,7 @@ type Input {
 
 """
 A [JSON](https://www.json.org/json-en.html) object.
+
 Example value:
 `{
   "product": {
@@ -202,14 +211,6 @@ input ProductVariantTarget {
 type Property {
   key: String!
   value: String!
-}
-
-"""
-The result of the function.
-"""
-input FunctionResult {
-  discountApplicationStrategy: DiscountApplicationStrategy!
-  discounts: [Discount!]!
 }
 
 type SellingPlan {

--- a/discounts/rust/product-discounts/default/schema.graphql
+++ b/discounts/rust/product-discounts/default/schema.graphql
@@ -1,0 +1,265 @@
+schema {
+  query: Input
+  mutation: MutationRoot
+}
+
+"""
+Exactly one field of input must be provided, and all others omitted.
+"""
+directive @oneOf on INPUT_OBJECT
+
+type Address {
+  city: String
+  countryCode: String
+  phone: String
+  poBox: Boolean!
+  provinceCode: String
+  zip: String
+}
+
+input Condition @oneOf {
+  productMinimumQuantity: ProductMinimumQuantity
+  productMinimumSubtotal: ProductMinimumSubtotal
+}
+
+type Customer implements HasMetafields {
+  acceptsMarketing: Boolean
+  email: String
+  id: ID
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+  orderCount: Int
+  phone: String
+  tags: [String!]
+  totalSpent: Money
+}
+
+type DeliveryLine {
+  destination: Address
+  id: ID
+  subscription: Boolean
+}
+
+input Discount {
+  conditions: [Condition!]
+  message: String
+  targets: [Target!]!
+  value: Value!
+}
+
+enum DiscountApplicationStrategy {
+  FIRST
+  MAXIMUM
+}
+
+input FixedAmount {
+  appliesToEachItem: Boolean
+  value: Float!
+}
+
+interface HasMetafields {
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+}
+
+"""
+Represents a unique identifier that is Base64 obfuscated. It is often used to
+refetch an object or as key for a cache. The ID type appears in a JSON response
+as a String; however, it is not intended to be human-readable. When expected as
+an input type, any string (such as `"VXNlci0xMA=="`) or integer (such as `4`)
+input value will be accepted as an ID.
+"""
+scalar ID
+
+type Input {
+  customer: Customer
+  deliveryLines: [DeliveryLine!]
+  locale: String
+  merchandiseLines: [MerchandiseLine!]
+}
+
+"""
+A [JSON](https://www.json.org/json-en.html) object.
+Example value:
+`{
+  "product": {
+    "id": "gid://shopify/Product/1346443542550",
+    "title": "White T-shirt",
+    "options": [{
+      "name": "Size",
+      "values": ["M", "L"]
+    }]
+  }
+}`
+"""
+scalar JSON
+
+type MerchandiseLine {
+  id: ID
+  price: Money!
+  properties: [Property!]
+  quantity: Int
+  sellingPlan: SellingPlan
+  variant: Variant
+  weight: Int
+}
+
+type Metafield {
+  type: String!
+  value: JSON!
+}
+
+type Money {
+  currency: String!
+  subunits: UnsignedInt64!
+}
+
+"""
+The root mutation for the API.
+"""
+type MutationRoot {
+  """
+  The mutation that defines the structure of a valid result for the function.
+  """
+  handleResult(
+    """
+    The result of the function.
+    """
+    result: FunctionResult!
+  ): Void!
+}
+
+input Percentage {
+  value: Float!
+}
+
+type Product implements HasMetafields {
+  giftCard: Boolean
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+  tags: [String!]
+  title: String
+  type: String
+  vendor: String
+}
+
+input ProductMinimumQuantity {
+  ids: [ID!]!
+  minimumQuantity: Int!
+  targetType: TargetType!
+}
+
+input ProductMinimumSubtotal {
+  ids: [ID!]!
+  minimumAmount: Float!
+  targetType: TargetType!
+}
+
+input ProductVariantTarget {
+  id: ID!
+  quantity: Int
+}
+
+type Property {
+  key: String!
+  value: String!
+}
+
+"""
+The result of the function.
+"""
+input FunctionResult {
+  discountApplicationStrategy: DiscountApplicationStrategy!
+  discounts: [Discount!]!
+}
+
+type SellingPlan {
+  id: ID!
+}
+
+input Target @oneOf {
+  productVariant: ProductVariantTarget
+}
+
+enum TargetType {
+  ORDER_SUBTOTAL
+  PRODUCT_VARIANT
+}
+
+"""
+Unsigned integer of up to 64 bit, encoded as a number (not a string).
+Example value: `1099511627776`
+"""
+scalar UnsignedInt64
+
+input Value @oneOf {
+  fixedAmount: FixedAmount
+  percentage: Percentage
+}
+
+type Variant implements HasMetafields {
+  compareAtPrice: Money
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+  product: Product
+  sku: String
+  title: String
+}
+
+"""
+A void type that can be used to return a null value from a mutation.
+"""
+scalar Void

--- a/discounts/rust/product-discounts/default/script.config.yml
+++ b/discounts/rust/product-discounts/default/script.config.yml
@@ -1,0 +1,19 @@
+---
+version: '2'
+configuration:
+  type: object
+  fields:
+    value:
+      type: number_decimal
+      name: Percentage off
+      validations:
+      - name: min
+        value: "0"
+      - name: max
+        value: "100"
+    excludedVariantIds:
+      type: array
+      name: Excluded Product Variants
+      elementType:
+        type: variant_reference
+        name: Product Variant

--- a/discounts/rust/product-discounts/default/src/api.rs
+++ b/discounts/rust/product-discounts/default/src/api.rs
@@ -1,12 +1,108 @@
 // Types defined in this file conforms to the schema https://github.com/Shopify/shopify/blob/main/db/graphql/shopify_vm/product_discounts.graphql
 #![allow(dead_code)]
-use serde::{Deserialize, Serialize};
-use serde_with::skip_serializing_none;
 
 pub type Boolean = bool;
 pub type Float = f64;
 pub type Int = i64;
 pub type ID = String;
+
+pub mod input {
+    use super::*;
+    use serde::Deserialize;
+    pub type UnsignedInt64 = u64;
+
+    #[derive(Clone, Debug, Deserialize)]
+    #[serde(rename_all(deserialize = "camelCase"))]
+    pub struct Input {
+        pub customer: Option<Customer>,
+        pub delivery_lines: Option<Vec<DeliveryLines>>,
+        pub locale: Option<String>,
+        pub merchandise_lines: Option<Vec<MerchandiseLine>>,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    #[serde(rename_all(deserialize = "camelCase"))]
+    pub struct Customer {
+        pub accepts_marketing: Option<Boolean>,
+        pub email: Option<String>,
+        pub id: Option<ID>,
+        pub order_count: Option<Int>,
+        pub phone: Option<String>,
+        pub tags: Option<Vec<String>>,
+        pub total_spent: Option<Money>,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    pub struct Money {
+        pub currency: String,
+        pub subunits: UnsignedInt64,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    pub struct DeliveryLines {
+        pub destination: Option<Address>,
+        pub id: Option<ID>,
+        pub subscription: Option<Boolean>,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    #[serde(rename_all(deserialize = "camelCase"))]
+    pub struct Address {
+        pub city: Option<String>,
+        pub country_code: Option<String>,
+        pub phone: Option<String>,
+        pub po_box: Boolean,
+        pub province_code: Option<String>,
+        pub zip: Option<String>,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    #[serde(rename_all(deserialize = "camelCase"))]
+    pub struct MerchandiseLine {
+        pub id: Option<ID>,
+        pub price: Option<Money>,
+        pub properties: Option<Vec<Properties>>,
+        pub quantity: Option<Int>,
+        pub selling_plan: Option<SellingPlan>,
+        pub variant: Option<Variant>,
+        pub weight: Option<Int>,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    pub struct Properties {
+        pub key: String,
+        pub value: String,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    pub struct SellingPlan {
+        pub id: ID,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    #[serde(rename_all(deserialize = "camelCase"))]
+    pub struct Variant {
+        pub compare_at_price: Option<Money>,
+        pub id: ID,
+        pub product: Option<Product>,
+        pub sku: Option<String>,
+        pub title: Option<String>,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    #[serde(rename_all(deserialize = "camelCase"))]
+    pub struct Product {
+        pub gift_card: Option<Boolean>,
+        pub id: ID,
+        pub tags: Option<Vec<String>>,
+        pub title: Option<String>,
+        pub type_: Option<String>,
+        pub vendor: Option<String>,
+    }
+}
+
+use serde::Serialize;
+use serde_with::skip_serializing_none;
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
@@ -78,20 +174,4 @@ pub enum Condition {
 #[serde(rename_all(serialize = "SCREAMING_SNAKE_CASE"))]
 pub enum ConditionTargetType {
     ProductVariant,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-#[serde(rename_all(deserialize = "camelCase"))]
-pub struct Input {
-    pub merchandise_lines: Option<Vec<MerchandiseLine>>,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-pub struct MerchandiseLine {
-    pub variant: Option<Variant>,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-pub struct Variant {
-    pub id: ID,
 }

--- a/discounts/rust/product-discounts/default/src/api.rs
+++ b/discounts/rust/product-discounts/default/src/api.rs
@@ -1,4 +1,5 @@
-// Types defined in this file conforms to the schema https://github.com/Shopify/shopify/blob/main/db/graphql/shopify_vm/product_discounts.graphql
+// Types defined in this file conforms to the schema https://github.com/Shopify/shopify/blob/main/db/graphql/shopify_vm/order_discounts.graphql
+// All input fields are optional as they may not be included in the input query
 #![allow(dead_code)]
 
 pub type Boolean = bool;
@@ -51,7 +52,7 @@ pub mod input {
         pub city: Option<String>,
         pub country_code: Option<String>,
         pub phone: Option<String>,
-        pub po_box: Boolean,
+        pub po_box: Option<Boolean>,
         pub province_code: Option<String>,
         pub zip: Option<String>,
     }
@@ -70,20 +71,20 @@ pub mod input {
 
     #[derive(Clone, Debug, Deserialize)]
     pub struct Properties {
-        pub key: String,
-        pub value: String,
+        pub key: Option<String>,
+        pub value: Option<String>,
     }
 
     #[derive(Clone, Debug, Deserialize)]
     pub struct SellingPlan {
-        pub id: ID,
+        pub id: Option<ID>,
     }
 
     #[derive(Clone, Debug, Deserialize)]
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Variant {
         pub compare_at_price: Option<Money>,
-        pub id: ID,
+        pub id: Option<ID>,
         pub product: Option<Product>,
         pub sku: Option<String>,
         pub title: Option<String>,
@@ -93,7 +94,7 @@ pub mod input {
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Product {
         pub gift_card: Option<Boolean>,
-        pub id: ID,
+        pub id: Option<ID>,
         pub tags: Option<Vec<String>>,
         pub title: Option<String>,
         pub type_: Option<String>,

--- a/discounts/rust/product-discounts/default/src/api.rs
+++ b/discounts/rust/product-discounts/default/src/api.rs
@@ -1,15 +1,26 @@
+// Types defined in this file conforms to the schema https://github.com/Shopify/shopify/blob/main/db/graphql/shopify_vm/product_discounts.graphql
+#![allow(dead_code)]
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
+
+pub type Boolean = bool;
+pub type Float = f64;
+pub type Int = i64;
+pub type ID = String;
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub struct FunctionResult {
-    pub discounts: Vec<Discount>,
     pub discount_application_strategy: DiscountApplicationStrategy,
+    pub discounts: Vec<Discount>,
 }
 
-pub type ID = String;
-pub type MoneySubunits = u64;
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "SCREAMING_SNAKE_CASE"))]
+pub enum DiscountApplicationStrategy {
+    First,
+    Maximum,
+}
 
 #[skip_serializing_none]
 #[derive(Clone, Debug, Serialize)]
@@ -17,7 +28,7 @@ pub struct Discount {
     pub value: Value,
     pub targets: Vec<Target>,
     pub message: Option<String>,
-    pub conditions: Option<Condition>,
+    pub conditions: Option<Vec<Condition>>,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -28,35 +39,38 @@ pub enum Value {
 }
 
 #[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
 pub struct FixedAmount {
-    pub value: MoneySubunits,
+    pub applies_to_each_item: Option<Boolean>,
+    pub value: Float,
 }
 
 #[derive(Clone, Debug, Serialize)]
 pub struct Percentage {
-    pub value: f64,
+    pub value: Float,
 }
 
 #[skip_serializing_none]
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub enum Target {
-    ProductVariant { id: ID, quantity: Option<u64> },
+    ProductVariant { id: ID, quantity: Option<Int> },
 }
 
 #[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
 pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     ProductMinimumQuantity {
+        ids: Vec<ID>,
+        minimum_quantity: Int,
         target_type: ConditionTargetType,
-        excluded_variant_ids: Vec<ID>,
-        minimum_amount: MoneySubunits,
     },
     #[serde(rename_all(serialize = "camelCase"))]
     ProductMinimumSubtotal {
+        ids: Vec<ID>,
+        minimum_amount: Float,
         target_type: ConditionTargetType,
-        excluded_variant_ids: Vec<ID>,
-        minimum_amount: MoneySubunits,
     },
 }
 
@@ -64,13 +78,6 @@ pub enum Condition {
 #[serde(rename_all(serialize = "SCREAMING_SNAKE_CASE"))]
 pub enum ConditionTargetType {
     ProductVariant,
-}
-
-#[derive(Clone, Debug, Serialize)]
-#[serde(rename_all(serialize = "SCREAMING_SNAKE_CASE"))]
-pub enum DiscountApplicationStrategy {
-    First,
-    Maximum,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/discounts/rust/product-discounts/default/src/api.rs
+++ b/discounts/rust/product-discounts/default/src/api.rs
@@ -15,7 +15,7 @@ pub mod input {
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Input {
         pub customer: Option<Customer>,
-        pub delivery_lines: Option<Vec<DeliveryLines>>,
+        pub delivery_lines: Option<Vec<DeliveryLine>>,
         pub locale: Option<String>,
         pub merchandise_lines: Option<Vec<MerchandiseLine>>,
     }
@@ -39,7 +39,7 @@ pub mod input {
     }
 
     #[derive(Clone, Debug, Deserialize)]
-    pub struct DeliveryLines {
+    pub struct DeliveryLine {
         pub destination: Option<Address>,
         pub id: Option<ID>,
         pub subscription: Option<Boolean>,

--- a/discounts/rust/product-discounts/default/src/api.rs
+++ b/discounts/rust/product-discounts/default/src/api.rs
@@ -1,0 +1,90 @@
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub struct FunctionResult {
+    pub discounts: Vec<Discount>,
+    pub discount_application_strategy: DiscountApplicationStrategy,
+}
+
+pub type ID = String;
+pub type MoneySubunits = u64;
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Serialize)]
+pub struct Discount {
+    pub value: Value,
+    pub targets: Vec<Target>,
+    pub message: Option<String>,
+    pub conditions: Option<Condition>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub enum Value {
+    FixedAmount(FixedAmount),
+    Percentage(Percentage),
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct FixedAmount {
+    pub value: MoneySubunits,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct Percentage {
+    pub value: f64,
+}
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub enum Target {
+    ProductVariant { id: ID, quantity: Option<u64> },
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub enum Condition {
+    #[serde(rename_all(serialize = "camelCase"))]
+    ProductMinimumQuantity {
+        target_type: ConditionTargetType,
+        excluded_variant_ids: Vec<ID>,
+        minimum_amount: MoneySubunits,
+    },
+    #[serde(rename_all(serialize = "camelCase"))]
+    ProductMinimumSubtotal {
+        target_type: ConditionTargetType,
+        excluded_variant_ids: Vec<ID>,
+        minimum_amount: MoneySubunits,
+    },
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "SCREAMING_SNAKE_CASE"))]
+pub enum ConditionTargetType {
+    ProductVariant,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "SCREAMING_SNAKE_CASE"))]
+pub enum DiscountApplicationStrategy {
+    First,
+    Maximum,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all(deserialize = "camelCase"))]
+pub struct Input {
+    pub merchandise_lines: Option<Vec<MerchandiseLine>>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct MerchandiseLine {
+    pub variant: Option<Variant>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Variant {
+    pub id: ID,
+}

--- a/discounts/rust/product-discounts/default/src/main.rs
+++ b/discounts/rust/product-discounts/default/src/main.rs
@@ -5,7 +5,7 @@ use api::*;
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Payload {
-    pub input: Input,
+    pub input: input::Input,
     pub configuration: Configuration,
 }
 
@@ -51,7 +51,10 @@ fn function(payload: Payload) -> Result<FunctionResult, Box<dyn std::error::Erro
     Ok(build_result(value, targets))
 }
 
-fn targets(merchandise_lines: &[MerchandiseLine], excluded_variant_ids: &[String]) -> Vec<Target> {
+fn targets(
+    merchandise_lines: &[input::MerchandiseLine],
+    excluded_variant_ids: &[String],
+) -> Vec<Target> {
     merchandise_lines
         .iter()
         .filter_map(|line| match line.variant {

--- a/discounts/rust/product-discounts/default/src/main.rs
+++ b/discounts/rust/product-discounts/default/src/main.rs
@@ -1,0 +1,222 @@
+use serde::{Deserialize, Serialize};
+
+use graphql_client::GraphQLQuery;
+
+type Void = ();
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "schema.graphql",
+    query_path = "input.graphql",
+    response_derives = "Debug, Clone, PartialEq",
+    normalization = "rust"
+)]
+struct Input;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "schema.graphql",
+    query_path = "handle-result.graphql",
+    response_derives = "Debug, Clone, PartialEq",
+    normalization = "rust"
+)]
+struct HandleResult;
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Config {
+    value: Option<String>,
+    excluded_variant_ids: Option<Vec<String>>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct Payload {
+    input: input::ResponseData,
+    configuration: Config,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let payload: Payload = serde_json::from_reader(std::io::BufReader::new(std::io::stdin()))?;
+    let mut out = std::io::stdout();
+    let mut serializer = serde_json::Serializer::new(&mut out);
+    script(payload)?.serialize(&mut serializer)?;
+    Ok(())
+}
+
+fn script(payload: Payload) -> Result<handle_result::FunctionResult, Box<dyn std::error::Error>> {
+    const DEFAULT_VALUE: f64 = 50.0;
+
+    let (input, config) = (payload.input, payload.configuration);
+    let value: f64 = if let Some(value) = config.value {
+        value.parse()?
+    } else {
+        DEFAULT_VALUE
+    };
+    let merchandise_lines = &input.merchandise_lines.unwrap_or_default();
+    let excluded_variant_ids = &config.excluded_variant_ids.unwrap_or_default();
+    let targets = targets(&merchandise_lines, &excluded_variant_ids);
+    Ok(build_result(value, targets))
+}
+
+fn targets(
+    merchandise_lines: &Vec<input::InputMerchandiseLines>,
+    excluded_variant_ids: &[String],
+) -> Vec<handle_result::Target> {
+    merchandise_lines
+        .iter()
+        .filter_map(|line| match line.variant {
+            Some(ref variant) if !excluded_variant_ids.contains(&(variant.id)) => {
+                Some(handle_result::Target {
+                    productVariant: Some(handle_result::ProductVariantTarget {
+                        id: variant.id,
+                        quantity: None,
+                    }),
+                })
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+fn build_result(value: f64, targets: Vec<handle_result::Target>) -> handle_result::FunctionResult {
+    handle_result::FunctionResult {
+        discounts: vec![handle_result::Discount {
+            message: Some(format!("{}% off", value)),
+            conditions: None,
+            targets,
+            value: handle_result::Value {
+                percentage: Some(handle_result::Percentage { value }),
+                fixedAmount: None,
+            },
+        }],
+        discountApplicationStrategy: handle_result::DiscountApplicationStrategy::First,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn payload(configuration: Config) -> Payload {
+        let input = r#"
+        {
+            "input": {
+                "merchandiseLines": [
+                    { "variant": { "id": "gid://shopify/ProductVariant/0" } },
+                    { "variant": { "id": "gid://shopify/ProductVariant/1" } }
+                ]
+            },
+            "configuration": {
+                "value": null,
+                "excludedVariantIds": null
+            }
+        }
+        "#;
+        let default_payload: Payload = serde_json::from_str(&input).unwrap();
+        Payload {
+            configuration,
+            ..default_payload
+        }
+    }
+
+    #[test]
+    fn test_discount_with_default_value() {
+        let payload = payload(Config {
+            value: None,
+            excluded_variant_ids: None,
+        });
+        let handle_result = serde_json::json!(script(payload).unwrap());
+
+        let expected_json = r#"
+            {
+                "discounts": [{
+                    "message": "50% off",
+                    "conditions": null,
+                    "targets": [
+                        { "productVariant": { "id": "gid://shopify/ProductVariant/0", "quantity": null } },
+                        { "productVariant": { "id": "gid://shopify/ProductVariant/1", "quantity": null } }
+                    ],
+                    "value": {
+                        "percentage": { "value": 50.0 },
+                        "fixedAmount": null
+                    }
+                }],
+                "discountApplicationStrategy": "FIRST"
+            }
+        "#;
+
+        let expected_handle_result: serde_json::Value =
+            serde_json::from_str(expected_json).unwrap();
+        assert_eq!(
+            handle_result.to_string(),
+            expected_handle_result.to_string()
+        );
+    }
+
+    #[test]
+    fn test_discount_with_value() {
+        let payload = payload(Config {
+            value: Some("10".to_string()),
+            excludedVariantIds: None,
+        });
+        let handle_result = serde_json::json!(script(payload).unwrap());
+
+        let expected_json = r#"
+            {
+                "discounts": [{
+                    "message": "10% off",
+                    "conditions": null,
+                    "targets": [
+                        { "productVariant": { "id": "gid://shopify/ProductVariant/0", "quantity": null } },
+                        { "productVariant": { "id": "gid://shopify/ProductVariant/1", "quantity": null } }
+                    ],
+                    "value": {
+                        "percentage": { "value": 10.0 },
+                        "fixedAmount": null
+                    }
+                }],
+                "discountApplicationStrategy": "FIRST"
+            }
+        "#;
+
+        let expected_handle_result: serde_json::Value =
+            serde_json::from_str(expected_json).unwrap();
+        assert_eq!(
+            handle_result.to_string(),
+            expected_handle_result.to_string()
+        );
+    }
+
+    #[test]
+    fn test_discount_with_excluded_variant_gids() {
+        let payload = payload(Config {
+            value: None,
+            excluded_variant_ids: Some(vec!["gid://shopify/ProductVariant/0".to_string()]),
+        });
+        let handle_result = serde_json::json!(script(payload).unwrap());
+
+        let expected_json = r#"
+            {
+                "discounts": [{
+                    "message": "50% off",
+                    "conditions": null,
+                    "targets": [
+                        { "productVariant": { "id": "gid://shopify/ProductVariant/1", "quantity": null } }
+                    ],
+                    "value": {
+                        "percentage": { "value": 50.0 },
+                        "fixedAmount": null
+                    }
+                }],
+                "discountApplicationStrategy": "FIRST"
+            }
+        "#;
+
+        let expected_handle_result: serde_json::Value =
+            serde_json::from_str(expected_json).unwrap();
+        assert_eq!(
+            handle_result.to_string(),
+            expected_handle_result.to_string()
+        );
+    }
+}

--- a/discounts/rust/product-discounts/default/src/main.rs
+++ b/discounts/rust/product-discounts/default/src/main.rs
@@ -13,7 +13,7 @@ pub struct Payload {
 #[serde(rename_all(deserialize = "camelCase"))]
 pub struct Configuration {
     pub value: Option<String>,
-    pub excluded_variant_ids: Option<Vec<String>>,
+    pub excluded_variant_ids: Option<Vec<ID>>,
 }
 
 impl Configuration {

--- a/discounts/rust/shipping-discounts/default/.gitignore
+++ b/discounts/rust/shipping-discounts/default/.gitignore
@@ -1,0 +1,3 @@
+/target
+/build
+Cargo.lock

--- a/discounts/rust/shipping-discounts/default/Cargo.toml
+++ b/discounts/rust/shipping-discounts/default/Cargo.toml
@@ -6,8 +6,8 @@ include = ["*.graphql"]
 
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }
+serde_with = "1.13.0"
 serde_json = "1.0"
-graphql_client = "0.10.0"
 
 [profile.release]
 lto = true

--- a/discounts/rust/shipping-discounts/default/Cargo.toml
+++ b/discounts/rust/shipping-discounts/default/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "shipping_discounts"
+version = "1.0.0"
+edition = "2021"
+include = ["*.graphql"]
+
+[dependencies]
+serde = { version = "1.0.13", features = ["derive"] }
+serde_json = "1.0"
+graphql_client = "0.10.0"
+
+[profile.release]
+lto = true
+opt-level = 's'
+strip = true

--- a/discounts/rust/shipping-discounts/default/Makefile
+++ b/discounts/rust/shipping-discounts/default/Makefile
@@ -1,0 +1,4 @@
+build_wasm:
+	mkdir -p build/ && \
+	cargo build --release --target "wasm32-wasi" && \
+	wasm-opt -O3 --strip-debug target/wasm32-wasi/release/*.wasm -o ./build/index.wasm

--- a/discounts/rust/shipping-discounts/default/Makefile
+++ b/discounts/rust/shipping-discounts/default/Makefile
@@ -1,4 +1,4 @@
 build_wasm:
 	mkdir -p build/ && \
 	cargo build --release --target "wasm32-wasi" && \
-	wasm-opt -O3 --strip-debug target/wasm32-wasi/release/*.wasm -o ./build/index.wasm
+	wasm-opt -Oz --strip-debug target/wasm32-wasi/release/*.wasm -o ./build/index.wasm

--- a/discounts/rust/shipping-discounts/default/README.md
+++ b/discounts/rust/shipping-discounts/default/README.md
@@ -1,0 +1,11 @@
+### Prerequisites
+
+* [Install Rust](https://www.rust-lang.org/tools/install)
+* Add `wasm32-wasi` target: `rustup target add wasm32-wasi`
+* Install `wasm-opt`: `brew install binaryen`
+
+### Build
+
+```
+make
+```

--- a/discounts/rust/shipping-discounts/default/README.md
+++ b/discounts/rust/shipping-discounts/default/README.md
@@ -1,11 +1,19 @@
-### Prerequisites
+## Dependencies
 
-* [Install Rust](https://www.rust-lang.org/tools/install)
-* Add `wasm32-wasi` target: `rustup target add wasm32-wasi`
-* Install `wasm-opt`: `brew install binaryen`
+### Rust
 
-### Build
+[Install Rust](https://www.rust-lang.org/tools/install)
 
-```
+Ensure you have the Wasm build target installed with `rustup show`. You should see `wasm32-wasi` as
+a build target. If not, install the build target via `rustup target add wasm32-wasi`.
+
+### `wasm-opt`
+Wasm-opt is part of binaryen. The easiest way to install binaryen on MacOS is `brew install binaryen` or you can download your OS-specific binary on the [release page](https://github.com/WebAssembly/binaryen/releases).
+
+## Building the script
+
+This builds the rust package to Wasm as `build/index.wasm` and strips it from its debug symbols.
+
+```sh
 make
 ```

--- a/discounts/rust/shipping-discounts/default/handle-result.graphql
+++ b/discounts/rust/shipping-discounts/default/handle-result.graphql
@@ -1,3 +1,0 @@
-mutation HandleResult($result: FunctionResult!) {
-  handleResult(result: $result)
-}

--- a/discounts/rust/shipping-discounts/default/handle-result.graphql
+++ b/discounts/rust/shipping-discounts/default/handle-result.graphql
@@ -1,0 +1,3 @@
+mutation HandleResult($result: FunctionResult!) {
+  handleResult(result: $result)
+}

--- a/discounts/rust/shipping-discounts/default/input.graphql
+++ b/discounts/rust/shipping-discounts/default/input.graphql
@@ -1,0 +1,5 @@
+query Input {
+  deliveryLines {
+    index
+  }
+}

--- a/discounts/rust/shipping-discounts/default/input.graphql
+++ b/discounts/rust/shipping-discounts/default/input.graphql
@@ -1,5 +1,5 @@
 query Input {
   deliveryLines {
-    index
+    id
   }
 }

--- a/discounts/rust/shipping-discounts/default/metadata.json
+++ b/discounts/rust/shipping-discounts/default/metadata.json
@@ -1,0 +1,1 @@
+{"schemaVersions":{"shipping_discounts":{"major":1,"minor":0}},"flags":{"use_msgpack":true}}

--- a/discounts/rust/shipping-discounts/default/schema.graphql
+++ b/discounts/rust/shipping-discounts/default/schema.graphql
@@ -1,0 +1,278 @@
+schema {
+  query: Input
+  mutation: MutationRoot
+}
+
+"""
+Exactly one field of input must be provided, and all others omitted.
+"""
+directive @oneOf on INPUT_OBJECT
+
+type Address {
+  city: String
+  countryCode: String
+  phone: String
+  poBox: Boolean!
+  provinceCode: String
+  zip: String
+}
+
+input Condition @oneOf {
+  orderMinimumSubtotal: OrderMinimumSubtotal
+  productMinimumQuantity: ProductMinimumQuantity
+  productMinimumSubtotal: ProductMinimumSubtotal
+}
+
+type Customer implements HasMetafields {
+  acceptsMarketing: Boolean
+  email: String
+  id: ID
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+  orderCount: Int
+  phone: String
+  tags: [String!]
+  totalSpent: Money
+}
+
+type DeliveryLineWithStrategy {
+  destination: Address
+  id: ID
+  price: Money!
+  strategy: DeliveryStrategy!
+  subscription: Boolean
+}
+
+type DeliveryStrategy {
+  code: String
+  name: String
+  source: String
+}
+
+input Discount {
+  conditions: [Condition!]
+  message: String
+  targets: [Target!]!
+  value: Value!
+}
+
+enum DiscountApplicationStrategy {
+  FIRST
+  MAXIMUM
+}
+
+input FixedAmount {
+  value: Float!
+}
+
+interface HasMetafields {
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+}
+
+"""
+Represents a unique identifier that is Base64 obfuscated. It is often used to
+refetch an object or as key for a cache. The ID type appears in a JSON response
+as a String; however, it is not intended to be human-readable. When expected as
+an input type, any string (such as `"VXNlci0xMA=="`) or integer (such as `4`)
+input value will be accepted as an ID.
+"""
+scalar ID
+
+type Input {
+  customer: Customer
+  deliveryLines: [DeliveryLineWithStrategy!]
+  locale: String
+  merchandiseLines: [MerchandiseLine!]
+}
+
+"""
+A [JSON](https://www.json.org/json-en.html) object.
+Example value:
+`{
+  "product": {
+    "id": "gid://shopify/Product/1346443542550",
+    "title": "White T-shirt",
+    "options": [{
+      "name": "Size",
+      "values": ["M", "L"]
+    }]
+  }
+}`
+"""
+scalar JSON
+
+type MerchandiseLine {
+  id: ID
+  price: Money!
+  properties: [Property!]
+  quantity: Int
+  sellingPlan: SellingPlan
+  variant: Variant
+  weight: Int
+}
+
+type Metafield {
+  type: String!
+  value: JSON!
+}
+
+type Money {
+  currency: String!
+  subunits: UnsignedInt64!
+}
+
+"""
+The root mutation for the API.
+"""
+type MutationRoot {
+  """
+  The mutation that defines the structure of a valid result for the function.
+  """
+  handleResult(
+    """
+    The result of the function.
+    """
+    result: FunctionResult!
+  ): Void!
+}
+
+input OrderMinimumSubtotal {
+  excludedVariantIds: [ID!]!
+  minimumAmount: Float!
+  targetType: TargetType!
+}
+
+input Percentage {
+  value: Float!
+}
+
+type Product implements HasMetafields {
+  giftCard: Boolean
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+  tags: [String!]
+  title: String
+  type: String
+  vendor: String
+}
+
+input ProductMinimumQuantity {
+  ids: [ID!]!
+  minimumQuantity: Int!
+  targetType: TargetType!
+}
+
+input ProductMinimumSubtotal {
+  ids: [ID!]!
+  minimumAmount: Float!
+  targetType: TargetType!
+}
+
+type Property {
+  key: String!
+  value: String!
+}
+
+"""
+The result of the function.
+"""
+input FunctionResult {
+  discountApplicationStrategy: DiscountApplicationStrategy!
+  discounts: [Discount!]!
+}
+
+type SellingPlan {
+  id: ID!
+}
+
+input ShippingLineTarget {
+  id: ID!
+}
+
+input Target @oneOf {
+  shippingLine: ShippingLineTarget
+}
+
+enum TargetType {
+  ORDER_SUBTOTAL
+  PRODUCT_VARIANT
+}
+
+"""
+Unsigned integer of up to 64 bit, encoded as a number (not a string).
+Example value: `1099511627776`
+"""
+scalar UnsignedInt64
+
+input Value @oneOf {
+  fixedAmount: FixedAmount
+  percentage: Percentage
+}
+
+type Variant implements HasMetafields {
+  compareAtPrice: Money
+  id: ID!
+
+  """
+  Returns a metafield by namespace and key that belongs to the resource.
+  """
+  metafield(
+    """
+    The key for the metafield.
+    """
+    key: String!
+
+    """
+    The namespace for the metafield.
+    """
+    namespace: String!
+  ): Metafield
+  product: Product
+  sku: String
+  title: String
+}
+
+"""
+A void type that can be used to return a null value from a mutation.
+"""
+scalar Void

--- a/discounts/rust/shipping-discounts/default/schema.graphql
+++ b/discounts/rust/shipping-discounts/default/schema.graphql
@@ -48,18 +48,10 @@ type Customer implements HasMetafields {
   totalSpent: Money
 }
 
-type DeliveryLineWithStrategy {
+type DeliveryLine {
   destination: Address
   id: ID
-  price: Money!
-  strategy: DeliveryStrategy!
   subscription: Boolean
-}
-
-type DeliveryStrategy {
-  code: String
-  name: String
-  source: String
 }
 
 input Discount {
@@ -76,6 +68,14 @@ enum DiscountApplicationStrategy {
 
 input FixedAmount {
   value: Float!
+}
+
+"""
+The result of the function.
+"""
+input FunctionResult {
+  discountApplicationStrategy: DiscountApplicationStrategy!
+  discounts: [Discount!]!
 }
 
 interface HasMetafields {
@@ -106,13 +106,14 @@ scalar ID
 
 type Input {
   customer: Customer
-  deliveryLines: [DeliveryLineWithStrategy!]
+  deliveryLines: [DeliveryLine!]
   locale: String
   merchandiseLines: [MerchandiseLine!]
 }
 
 """
 A [JSON](https://www.json.org/json-en.html) object.
+
 Example value:
 `{
   "product": {
@@ -168,6 +169,10 @@ input OrderMinimumSubtotal {
   targetType: TargetType!
 }
 
+input OrderSubtotalTarget {
+  excludedVariantIds: [ID!]!
+}
+
 input Percentage {
   value: Float!
 }
@@ -208,29 +213,23 @@ input ProductMinimumSubtotal {
   targetType: TargetType!
 }
 
+input ProductVariantTarget {
+  id: ID!
+  quantity: Int
+}
+
 type Property {
   key: String!
   value: String!
-}
-
-"""
-The result of the function.
-"""
-input FunctionResult {
-  discountApplicationStrategy: DiscountApplicationStrategy!
-  discounts: [Discount!]!
 }
 
 type SellingPlan {
   id: ID!
 }
 
-input ShippingLineTarget {
-  id: ID!
-}
-
 input Target @oneOf {
-  shippingLine: ShippingLineTarget
+  orderSubtotal: OrderSubtotalTarget
+  productVariant: ProductVariantTarget
 }
 
 enum TargetType {

--- a/discounts/rust/shipping-discounts/default/script.config.yml
+++ b/discounts/rust/shipping-discounts/default/script.config.yml
@@ -1,0 +1,13 @@
+---
+version: '2'
+configuration:
+  type: object
+  fields:
+    value:
+      type: number_decimal
+      name: Percentage off
+      validations:
+      - name: min
+        value: "0"
+      - name: max
+        value: "100"

--- a/discounts/rust/shipping-discounts/default/src/api.rs
+++ b/discounts/rust/shipping-discounts/default/src/api.rs
@@ -1,0 +1,92 @@
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub struct FunctionResult {
+    pub discounts: Vec<Discount>,
+    pub discount_application_strategy: DiscountApplicationStrategy,
+}
+
+pub type ID = String;
+pub type MoneySubunits = u64;
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Serialize)]
+pub struct Discount {
+    pub value: Value,
+    pub targets: Vec<Target>,
+    pub message: Option<String>,
+    pub conditions: Option<Condition>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub enum Value {
+    FixedAmount(FixedAmount),
+    Percentage(Percentage),
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct FixedAmount {
+    pub value: MoneySubunits,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct Percentage {
+    pub value: f64,
+}
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub enum Target {
+    ShippingLine { id: ID },
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub enum Condition {
+    #[serde(rename_all(serialize = "camelCase"))]
+    OrderMinimumSubtotal {
+        target_type: ConditionTargetType,
+        excluded_variant_ids: Vec<ID>,
+        minimum_amount: MoneySubunits,
+    },
+    #[serde(rename_all(serialize = "camelCase"))]
+    ProductMinimumQuantity {
+        target_type: ConditionTargetType,
+        excluded_variant_ids: Vec<ID>,
+        minimum_amount: MoneySubunits,
+    },
+    #[serde(rename_all(serialize = "camelCase"))]
+    ProductMinimumSubtotal {
+        target_type: ConditionTargetType,
+        excluded_variant_ids: Vec<ID>,
+        minimum_amount: MoneySubunits,
+    },
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "SCREAMING_SNAKE_CASE"))]
+pub enum ConditionTargetType {
+    OrderSubtotal,
+    ProductVariant,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "SCREAMING_SNAKE_CASE"))]
+pub enum DiscountApplicationStrategy {
+    First,
+    Maximum,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all(deserialize = "camelCase"))]
+pub struct Input {
+    pub delivery_lines: Option<Vec<DeliveryLineWithStrategy>>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct DeliveryLineWithStrategy {
+    pub id: Option<ID>,
+}

--- a/discounts/rust/shipping-discounts/default/src/api.rs
+++ b/discounts/rust/shipping-discounts/default/src/api.rs
@@ -1,4 +1,5 @@
 // Types defined in this file conforms to the schema https://github.com/Shopify/shopify/blob/main/db/graphql/shopify_vm/shipping_discounts.graphql
+// All input fields are optional as they may not be included in the input query
 #![allow(dead_code)]
 
 pub type Boolean = bool;
@@ -60,7 +61,7 @@ pub mod input {
         pub city: Option<String>,
         pub country_code: Option<String>,
         pub phone: Option<String>,
-        pub po_box: Boolean,
+        pub po_box: Option<Boolean>,
         pub province_code: Option<String>,
         pub zip: Option<String>,
     }
@@ -79,20 +80,20 @@ pub mod input {
 
     #[derive(Clone, Debug, Deserialize)]
     pub struct Properties {
-        pub key: String,
-        pub value: String,
+        pub key: Option<String>,
+        pub value: Option<String>,
     }
 
     #[derive(Clone, Debug, Deserialize)]
     pub struct SellingPlan {
-        pub id: ID,
+        pub id: Option<ID>,
     }
 
     #[derive(Clone, Debug, Deserialize)]
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Variant {
         pub compare_at_price: Option<Money>,
-        pub id: ID,
+        pub id: Option<ID>,
         pub product: Option<Product>,
         pub sku: Option<String>,
         pub title: Option<String>,
@@ -102,7 +103,7 @@ pub mod input {
     #[serde(rename_all(deserialize = "camelCase"))]
     pub struct Product {
         pub gift_card: Option<Boolean>,
-        pub id: ID,
+        pub id: Option<ID>,
         pub tags: Option<Vec<String>>,
         pub title: Option<String>,
         pub type_: Option<String>,

--- a/discounts/rust/shipping-discounts/default/src/api.rs
+++ b/discounts/rust/shipping-discounts/default/src/api.rs
@@ -1,15 +1,131 @@
-use serde::{Deserialize, Serialize};
+// Types defined in this file conforms to the schema https://github.com/Shopify/shopify/blob/main/db/graphql/shopify_vm/shipping_discounts.graphql
+#![allow(dead_code)]
+
+pub type Boolean = bool;
+pub type Float = f64;
+pub type Int = i64;
+pub type ID = String;
+
+pub mod input {
+    use super::*;
+    use serde::Deserialize;
+    pub type UnsignedInt64 = u64;
+
+    #[derive(Clone, Debug, Deserialize)]
+    #[serde(rename_all(deserialize = "camelCase"))]
+    pub struct Input {
+        pub customer: Option<Customer>,
+        pub delivery_lines: Option<Vec<DeliveryLineWithStrategy>>,
+        pub locale: Option<String>,
+        pub merchandise_lines: Option<Vec<MerchandiseLine>>,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    #[serde(rename_all(deserialize = "camelCase"))]
+    pub struct Customer {
+        pub accepts_marketing: Option<Boolean>,
+        pub email: Option<String>,
+        pub id: Option<ID>,
+        pub order_count: Option<Int>,
+        pub phone: Option<String>,
+        pub tags: Option<Vec<String>>,
+        pub total_spent: Option<Money>,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    pub struct Money {
+        pub currency: String,
+        pub subunits: UnsignedInt64,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    pub struct DeliveryLineWithStrategy {
+        pub destination: Option<Address>,
+        pub id: Option<ID>,
+        pub price: Option<Money>,
+        pub strategy: Option<DeliveryStrategy>,
+        pub subscription: Option<Boolean>,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    pub struct DeliveryStrategy {
+        code: Option<String>,
+        name: Option<String>,
+        source: Option<String>,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    #[serde(rename_all(deserialize = "camelCase"))]
+    pub struct Address {
+        pub city: Option<String>,
+        pub country_code: Option<String>,
+        pub phone: Option<String>,
+        pub po_box: Boolean,
+        pub province_code: Option<String>,
+        pub zip: Option<String>,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    #[serde(rename_all(deserialize = "camelCase"))]
+    pub struct MerchandiseLine {
+        pub id: Option<ID>,
+        pub price: Option<Money>,
+        pub properties: Option<Vec<Properties>>,
+        pub quantity: Option<Int>,
+        pub selling_plan: Option<SellingPlan>,
+        pub variant: Option<Variant>,
+        pub weight: Option<Int>,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    pub struct Properties {
+        pub key: String,
+        pub value: String,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    pub struct SellingPlan {
+        pub id: ID,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    #[serde(rename_all(deserialize = "camelCase"))]
+    pub struct Variant {
+        pub compare_at_price: Option<Money>,
+        pub id: ID,
+        pub product: Option<Product>,
+        pub sku: Option<String>,
+        pub title: Option<String>,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    #[serde(rename_all(deserialize = "camelCase"))]
+    pub struct Product {
+        pub gift_card: Option<Boolean>,
+        pub id: ID,
+        pub tags: Option<Vec<String>>,
+        pub title: Option<String>,
+        pub type_: Option<String>,
+        pub vendor: Option<String>,
+    }
+}
+
+use serde::Serialize;
 use serde_with::skip_serializing_none;
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub struct FunctionResult {
-    pub discounts: Vec<Discount>,
     pub discount_application_strategy: DiscountApplicationStrategy,
+    pub discounts: Vec<Discount>,
 }
 
-pub type ID = String;
-pub type MoneySubunits = u64;
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "SCREAMING_SNAKE_CASE"))]
+pub enum DiscountApplicationStrategy {
+    First,
+    Maximum,
+}
 
 #[skip_serializing_none]
 #[derive(Clone, Debug, Serialize)]
@@ -17,7 +133,7 @@ pub struct Discount {
     pub value: Value,
     pub targets: Vec<Target>,
     pub message: Option<String>,
-    pub conditions: Option<Condition>,
+    pub conditions: Option<Vec<Condition>>,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -28,13 +144,14 @@ pub enum Value {
 }
 
 #[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
 pub struct FixedAmount {
-    pub value: MoneySubunits,
+    pub value: Float,
 }
 
 #[derive(Clone, Debug, Serialize)]
 pub struct Percentage {
-    pub value: f64,
+    pub value: Float,
 }
 
 #[skip_serializing_none]
@@ -45,24 +162,25 @@ pub enum Target {
 }
 
 #[derive(Clone, Debug, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
 pub enum Condition {
     #[serde(rename_all(serialize = "camelCase"))]
     OrderMinimumSubtotal {
-        target_type: ConditionTargetType,
         excluded_variant_ids: Vec<ID>,
-        minimum_amount: MoneySubunits,
+        minimum_amount: Float,
+        target_type: ConditionTargetType,
     },
     #[serde(rename_all(serialize = "camelCase"))]
     ProductMinimumQuantity {
+        ids: Vec<ID>,
+        minimum_quantity: Int,
         target_type: ConditionTargetType,
-        excluded_variant_ids: Vec<ID>,
-        minimum_amount: MoneySubunits,
     },
     #[serde(rename_all(serialize = "camelCase"))]
     ProductMinimumSubtotal {
+        ids: Vec<ID>,
+        minimum_amount: Float,
         target_type: ConditionTargetType,
-        excluded_variant_ids: Vec<ID>,
-        minimum_amount: MoneySubunits,
     },
 }
 
@@ -71,22 +189,4 @@ pub enum Condition {
 pub enum ConditionTargetType {
     OrderSubtotal,
     ProductVariant,
-}
-
-#[derive(Clone, Debug, Serialize)]
-#[serde(rename_all(serialize = "SCREAMING_SNAKE_CASE"))]
-pub enum DiscountApplicationStrategy {
-    First,
-    Maximum,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-#[serde(rename_all(deserialize = "camelCase"))]
-pub struct Input {
-    pub delivery_lines: Option<Vec<DeliveryLineWithStrategy>>,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-pub struct DeliveryLineWithStrategy {
-    pub id: Option<ID>,
 }

--- a/discounts/rust/shipping-discounts/default/src/main.rs
+++ b/discounts/rust/shipping-discounts/default/src/main.rs
@@ -1,0 +1,160 @@
+use serde::{Deserialize, Serialize};
+
+use graphql_client::GraphQLQuery;
+
+type UnsignedInt64 = u64;
+type Void = ();
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "schema.graphql",
+    query_path = "input.graphql",
+    response_derives = "Debug, Clone, PartialEq",
+    normalization = "rust"
+)]
+struct Input;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "schema.graphql",
+    query_path = "output.graphql",
+    response_derives = "Debug, Clone, PartialEq",
+    normalization = "rust"
+)]
+struct HandleResult;
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Config {
+    value: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct Payload {
+    input: input::ResponseData,
+    configuration: Config,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let payload: Payload = serde_json::from_reader(std::io::BufReader::new(std::io::stdin()))?;
+    let mut out = std::io::stdout();
+    let mut serializer = serde_json::Serializer::new(&mut out);
+    script(payload)?.serialize(&mut serializer)?;
+    Ok(())
+}
+
+fn script(payload: Payload) -> Result<handle_result::FunctionResult, Box<dyn std::error::Error>> {
+    const DEFAULT_VALUE: f64 = 50.0;
+
+    let (input, config) = (payload.input, payload.configuration);
+    let value: f64 = if let Some(value) = config.value {
+        value.parse()?
+    } else {
+        DEFAULT_VALUE
+    };
+    let delivery_lines = &input.delivery_lines.unwrap_or_default();
+    let targets = delivery_lines
+        .iter()
+        .map(|line| handle_result::Target {
+            shippingLine: Some(handle_result::ShippingLineTarget { id: line.id }),
+        })
+        .collect();
+    Ok(build_result(value, targets))
+}
+
+fn build_result(value: f64, targets: Vec<handle_result::Target>) -> handle_result::FunctionResult {
+    handle_result::FunctionResult {
+        discounts: vec![handle_result::Discount {
+            message: Some(format!("{}% off", value)),
+            conditions: None,
+            targets,
+            value: handle_result::Value {
+                percentage: Some(handle_result::Percentage { value }),
+                fixedAmount: None,
+            },
+        }],
+        discountApplicationStrategy: handle_result::DiscountApplicationStrategy::First,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn payload(configuration: Config) -> Payload {
+        let input = r#"
+        {
+            "input": {
+                "deliveryLines": [
+                    { "id": "gid://shopify/DeliveryLine/0" },
+                    { "id": "gid://shopify/DeliveryLine/1" }
+                ]
+            },
+            "configuration": {
+                "value": null
+            }
+        }
+        "#;
+        let default_payload: Payload = serde_json::from_str(&input).unwrap();
+        Payload {
+            configuration,
+            ..default_payload
+        }
+    }
+
+    #[test]
+    fn test_discount_with_default_value() {
+        let payload = payload(Config { value: None });
+        let output = serde_json::json!(script(payload).unwrap());
+
+        let expected_json = r#"
+            {
+                "discounts": [{
+                    "message": "50% off",
+                    "conditions": null,
+                    "targets": [
+                        { "shippingLine": { "id": "gid://shopify/DeliveryLine/0" } },
+                        { "shippingLine": { "id": "gid://shopify/DeliveryLine/1" } }
+                    ],
+                    "value": {
+                        "percentage": { "value": 50.0 },
+                        "fixedAmount": null
+                    }
+                }],
+                "discountApplicationStrategy": "FIRST"
+            }
+        "#;
+
+        let expected_output: serde_json::Value = serde_json::from_str(expected_json).unwrap();
+        assert_eq!(output.to_string(), expected_output.to_string());
+    }
+
+    #[test]
+    fn test_discount_with_value() {
+        let payload = payload(Config {
+            value: Some("10".to_string()),
+        });
+        let output = serde_json::json!(script(payload).unwrap());
+
+        let expected_json = r#"
+            {
+                "discounts": [{
+                    "message": "10% off",
+                    "conditions": null,
+                    "targets": [
+                        { "shippingLine": { "id": "gid://shopify/DeliveryLine/0" } },
+                        { "shippingLine": { "id": "gid://shopify/DeliveryLine/1" } }
+                    ],
+                    "value": {
+                        "percentage": { "value": 10.0 },
+                        "fixedAmount": null
+                    }
+                }],
+                "discountApplicationStrategy": "FIRST"
+            }
+        "#;
+
+        let expected_output: serde_json::Value = serde_json::from_str(expected_json).unwrap();
+        assert_eq!(output.to_string(), expected_output.to_string());
+    }
+}

--- a/discounts/rust/shipping-discounts/default/src/main.rs
+++ b/discounts/rust/shipping-discounts/default/src/main.rs
@@ -5,7 +5,7 @@ use api::*;
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Payload {
-    pub input: Input,
+    pub input: input::Input,
     pub configuration: Configuration,
 }
 
@@ -38,16 +38,16 @@ fn function(payload: Payload) -> Result<FunctionResult, Box<dyn std::error::Erro
     let value = config.get_value();
     Ok(FunctionResult {
         discounts: vec![Discount {
-            value: Value::Percentage(Percentage { value }),
-            targets: targets(&input.delivery_lines.unwrap_or_default()),
             message: Some(format!("{}% off", value)),
             conditions: None,
+            value: Value::Percentage(Percentage { value }),
+            targets: targets(&input.delivery_lines.unwrap_or_default()),
         }],
         discount_application_strategy: DiscountApplicationStrategy::First,
     })
 }
 
-fn targets(delivery_lines: &[DeliveryLineWithStrategy]) -> Vec<Target> {
+fn targets(delivery_lines: &[input::DeliveryLineWithStrategy]) -> Vec<Target> {
     delivery_lines
         .iter()
         .filter_map(|line| {
@@ -67,8 +67,8 @@ mod tests {
         {
             "input": {
                 "deliveryLines": [
-                    { "id": "gid://shopify/DeliveryLine/0" },
-                    { "id": "gid://shopify/DeliveryLine/1" }
+                    { "id": "gid://shopify/DeliveryLine/0", "price": { "currency": "CAD", "subunits": 100 }, "strategy": {} },
+                    { "id": "gid://shopify/DeliveryLine/1", "price": { "currency": "CAD", "subunits": 100 }, "strategy": {} }
                 ]
             },
             "configuration": {

--- a/discounts/rust/shipping-discounts/default/src/main.rs
+++ b/discounts/rust/shipping-discounts/default/src/main.rs
@@ -67,8 +67,8 @@ mod tests {
         {
             "input": {
                 "deliveryLines": [
-                    { "id": "gid://shopify/DeliveryLine/0", "price": { "currency": "CAD", "subunits": 100 }, "strategy": {} },
-                    { "id": "gid://shopify/DeliveryLine/1", "price": { "currency": "CAD", "subunits": 100 }, "strategy": {} }
+                    { "id": "gid://shopify/DeliveryLine/0" },
+                    { "id": "gid://shopify/DeliveryLine/1" }
                 ]
             },
             "configuration": {

--- a/discounts/wasm/order-discounts/default/schema.graphql
+++ b/discounts/wasm/order-discounts/default/schema.graphql
@@ -1,6 +1,12 @@
 schema {
-  query: MerchandiseDiscountRoot
+  query: Input
+  mutation: MutationRoot
 }
+
+"""
+Exactly one field of input must be provided, and all others omitted.
+"""
+directive @oneOf on INPUT_OBJECT
 
 type Address {
   city: String
@@ -11,10 +17,16 @@ type Address {
   zip: String
 }
 
+input Condition @oneOf {
+  orderMinimumSubtotal: OrderMinimumSubtotal
+  productMinimumQuantity: ProductMinimumQuantity
+  productMinimumSubtotal: ProductMinimumSubtotal
+}
+
 type Customer implements HasMetafields {
   acceptsMarketing: Boolean
   email: String
-  id: UnsignedInt64!
+  id: ID
 
   """
   Returns a metafield by namespace and key that belongs to the resource.
@@ -38,8 +50,32 @@ type Customer implements HasMetafields {
 
 type DeliveryLine {
   destination: Address
-  index: Int
+  id: ID
   subscription: Boolean
+}
+
+input Discount {
+  conditions: [Condition!]
+  message: String
+  targets: [Target!]!
+  value: Value!
+}
+
+enum DiscountApplicationStrategy {
+  FIRST
+  MAXIMUM
+}
+
+input FixedAmount {
+  value: Float!
+}
+
+"""
+The result of the function.
+"""
+input FunctionResult {
+  discountApplicationStrategy: DiscountApplicationStrategy!
+  discounts: [Discount!]!
 }
 
 interface HasMetafields {
@@ -60,6 +96,22 @@ interface HasMetafields {
 }
 
 """
+Represents a unique identifier that is Base64 obfuscated. It is often used to
+refetch an object or as key for a cache. The ID type appears in a JSON response
+as a String; however, it is not intended to be human-readable. When expected as
+an input type, any string (such as `"VXNlci0xMA=="`) or integer (such as `4`)
+input value will be accepted as an ID.
+"""
+scalar ID
+
+type Input {
+  customer: Customer
+  deliveryLines: [DeliveryLine!]
+  locale: String
+  merchandiseLines: [MerchandiseLine!]
+}
+
+"""
 A [JSON](https://www.json.org/json-en.html) object.
 
 Example value:
@@ -76,15 +128,8 @@ Example value:
 """
 scalar JSON
 
-type MerchandiseDiscountRoot {
-  customer: Customer
-  deliveryLines: [DeliveryLine!]
-  locale: String
-  merchandiseLines: [MerchandiseLine!]
-}
-
 type MerchandiseLine {
-  index: Int
+  id: ID
   price: Money!
   properties: [Property!]
   quantity: Int
@@ -103,9 +148,38 @@ type Money {
   subunits: UnsignedInt64!
 }
 
+"""
+The root mutation for the API.
+"""
+type MutationRoot {
+  """
+  The mutation that defines the structure of a valid result for the function.
+  """
+  handleResult(
+    """
+    The result of the function.
+    """
+    result: FunctionResult!
+  ): Void!
+}
+
+input OrderMinimumSubtotal {
+  excludedVariantIds: [ID!]!
+  minimumAmount: Float!
+  targetType: TargetType!
+}
+
+input OrderSubtotalTarget {
+  excludedVariantIds: [ID!]!
+}
+
+input Percentage {
+  value: Float!
+}
+
 type Product implements HasMetafields {
   giftCard: Boolean
-  id: UnsignedInt64!
+  id: ID!
 
   """
   Returns a metafield by namespace and key that belongs to the resource.
@@ -127,13 +201,40 @@ type Product implements HasMetafields {
   vendor: String
 }
 
+input ProductMinimumQuantity {
+  ids: [ID!]!
+  minimumQuantity: Int!
+  targetType: TargetType!
+}
+
+input ProductMinimumSubtotal {
+  ids: [ID!]!
+  minimumAmount: Float!
+  targetType: TargetType!
+}
+
+input ProductVariantTarget {
+  id: ID!
+  quantity: Int
+}
+
 type Property {
   key: String!
   value: String!
 }
 
 type SellingPlan {
-  id: UnsignedInt64!
+  id: ID!
+}
+
+input Target @oneOf {
+  orderSubtotal: OrderSubtotalTarget
+  productVariant: ProductVariantTarget
+}
+
+enum TargetType {
+  ORDER_SUBTOTAL
+  PRODUCT_VARIANT
 }
 
 """
@@ -142,9 +243,14 @@ Example value: `1099511627776`
 """
 scalar UnsignedInt64
 
+input Value @oneOf {
+  fixedAmount: FixedAmount
+  percentage: Percentage
+}
+
 type Variant implements HasMetafields {
   compareAtPrice: Money
-  id: UnsignedInt64!
+  id: ID!
 
   """
   Returns a metafield by namespace and key that belongs to the resource.
@@ -164,3 +270,8 @@ type Variant implements HasMetafields {
   sku: String
   title: String
 }
+
+"""
+A void type that can be used to return a null value from a mutation.
+"""
+scalar Void

--- a/discounts/wasm/product-discounts/default/schema.graphql
+++ b/discounts/wasm/product-discounts/default/schema.graphql
@@ -1,6 +1,12 @@
 schema {
-  query: MerchandiseDiscountRoot
+  query: Input
+  mutation: MutationRoot
 }
+
+"""
+Exactly one field of input must be provided, and all others omitted.
+"""
+directive @oneOf on INPUT_OBJECT
 
 type Address {
   city: String
@@ -11,10 +17,15 @@ type Address {
   zip: String
 }
 
+input Condition @oneOf {
+  productMinimumQuantity: ProductMinimumQuantity
+  productMinimumSubtotal: ProductMinimumSubtotal
+}
+
 type Customer implements HasMetafields {
   acceptsMarketing: Boolean
   email: String
-  id: UnsignedInt64!
+  id: ID
 
   """
   Returns a metafield by namespace and key that belongs to the resource.
@@ -38,8 +49,33 @@ type Customer implements HasMetafields {
 
 type DeliveryLine {
   destination: Address
-  index: Int
+  id: ID
   subscription: Boolean
+}
+
+input Discount {
+  conditions: [Condition!]
+  message: String
+  targets: [Target!]!
+  value: Value!
+}
+
+enum DiscountApplicationStrategy {
+  FIRST
+  MAXIMUM
+}
+
+input FixedAmount {
+  appliesToEachItem: Boolean
+  value: Float!
+}
+
+"""
+The result of the function.
+"""
+input FunctionResult {
+  discountApplicationStrategy: DiscountApplicationStrategy!
+  discounts: [Discount!]!
 }
 
 interface HasMetafields {
@@ -60,6 +96,22 @@ interface HasMetafields {
 }
 
 """
+Represents a unique identifier that is Base64 obfuscated. It is often used to
+refetch an object or as key for a cache. The ID type appears in a JSON response
+as a String; however, it is not intended to be human-readable. When expected as
+an input type, any string (such as `"VXNlci0xMA=="`) or integer (such as `4`)
+input value will be accepted as an ID.
+"""
+scalar ID
+
+type Input {
+  customer: Customer
+  deliveryLines: [DeliveryLine!]
+  locale: String
+  merchandiseLines: [MerchandiseLine!]
+}
+
+"""
 A [JSON](https://www.json.org/json-en.html) object.
 
 Example value:
@@ -76,15 +128,8 @@ Example value:
 """
 scalar JSON
 
-type MerchandiseDiscountRoot {
-  customer: Customer
-  deliveryLines: [DeliveryLine!]
-  locale: String
-  merchandiseLines: [MerchandiseLine!]
-}
-
 type MerchandiseLine {
-  index: Int
+  id: ID
   price: Money!
   properties: [Property!]
   quantity: Int
@@ -103,9 +148,28 @@ type Money {
   subunits: UnsignedInt64!
 }
 
+"""
+The root mutation for the API.
+"""
+type MutationRoot {
+  """
+  The mutation that defines the structure of a valid result for the function.
+  """
+  handleResult(
+    """
+    The result of the function.
+    """
+    result: FunctionResult!
+  ): Void!
+}
+
+input Percentage {
+  value: Float!
+}
+
 type Product implements HasMetafields {
   giftCard: Boolean
-  id: UnsignedInt64!
+  id: ID!
 
   """
   Returns a metafield by namespace and key that belongs to the resource.
@@ -127,13 +191,39 @@ type Product implements HasMetafields {
   vendor: String
 }
 
+input ProductMinimumQuantity {
+  ids: [ID!]!
+  minimumQuantity: Int!
+  targetType: TargetType!
+}
+
+input ProductMinimumSubtotal {
+  ids: [ID!]!
+  minimumAmount: Float!
+  targetType: TargetType!
+}
+
+input ProductVariantTarget {
+  id: ID!
+  quantity: Int
+}
+
 type Property {
   key: String!
   value: String!
 }
 
 type SellingPlan {
-  id: UnsignedInt64!
+  id: ID!
+}
+
+input Target @oneOf {
+  productVariant: ProductVariantTarget
+}
+
+enum TargetType {
+  ORDER_SUBTOTAL
+  PRODUCT_VARIANT
 }
 
 """
@@ -142,9 +232,14 @@ Example value: `1099511627776`
 """
 scalar UnsignedInt64
 
+input Value @oneOf {
+  fixedAmount: FixedAmount
+  percentage: Percentage
+}
+
 type Variant implements HasMetafields {
   compareAtPrice: Money
-  id: UnsignedInt64!
+  id: ID!
 
   """
   Returns a metafield by namespace and key that belongs to the resource.
@@ -164,3 +259,8 @@ type Variant implements HasMetafields {
   sku: String
   title: String
 }
+
+"""
+A void type that can be used to return a null value from a mutation.
+"""
+scalar Void

--- a/discounts/wasm/shipping-discounts/default/schema.graphql
+++ b/discounts/wasm/shipping-discounts/default/schema.graphql
@@ -1,6 +1,12 @@
 schema {
-  query: DeliveryDiscountRoot
+  query: Input
+  mutation: MutationRoot
 }
+
+"""
+Exactly one field of input must be provided, and all others omitted.
+"""
+directive @oneOf on INPUT_OBJECT
 
 type Address {
   city: String
@@ -11,10 +17,16 @@ type Address {
   zip: String
 }
 
+input Condition @oneOf {
+  orderMinimumSubtotal: OrderMinimumSubtotal
+  productMinimumQuantity: ProductMinimumQuantity
+  productMinimumSubtotal: ProductMinimumSubtotal
+}
+
 type Customer implements HasMetafields {
   acceptsMarketing: Boolean
   email: String
-  id: UnsignedInt64!
+  id: ID
 
   """
   Returns a metafield by namespace and key that belongs to the resource.
@@ -36,25 +48,34 @@ type Customer implements HasMetafields {
   totalSpent: Money
 }
 
-type DeliveryDiscountRoot {
-  customer: Customer
-  deliveryLines: [DeliveryLineWithStrategy!]
-  locale: String
-  merchandiseLines: [MerchandiseLine!]
-}
-
-type DeliveryLineWithStrategy {
+type DeliveryLine {
   destination: Address
-  index: Int
-  price: Money!
-  strategy: DeliveryStrategy!
+  id: ID
   subscription: Boolean
 }
 
-type DeliveryStrategy {
-  code: String
-  name: String
-  source: String
+input Discount {
+  conditions: [Condition!]
+  message: String
+  targets: [Target!]!
+  value: Value!
+}
+
+enum DiscountApplicationStrategy {
+  FIRST
+  MAXIMUM
+}
+
+input FixedAmount {
+  value: Float!
+}
+
+"""
+The result of the function.
+"""
+input FunctionResult {
+  discountApplicationStrategy: DiscountApplicationStrategy!
+  discounts: [Discount!]!
 }
 
 interface HasMetafields {
@@ -75,6 +96,22 @@ interface HasMetafields {
 }
 
 """
+Represents a unique identifier that is Base64 obfuscated. It is often used to
+refetch an object or as key for a cache. The ID type appears in a JSON response
+as a String; however, it is not intended to be human-readable. When expected as
+an input type, any string (such as `"VXNlci0xMA=="`) or integer (such as `4`)
+input value will be accepted as an ID.
+"""
+scalar ID
+
+type Input {
+  customer: Customer
+  deliveryLines: [DeliveryLine!]
+  locale: String
+  merchandiseLines: [MerchandiseLine!]
+}
+
+"""
 A [JSON](https://www.json.org/json-en.html) object.
 
 Example value:
@@ -92,7 +129,7 @@ Example value:
 scalar JSON
 
 type MerchandiseLine {
-  index: Int
+  id: ID
   price: Money!
   properties: [Property!]
   quantity: Int
@@ -111,9 +148,38 @@ type Money {
   subunits: UnsignedInt64!
 }
 
+"""
+The root mutation for the API.
+"""
+type MutationRoot {
+  """
+  The mutation that defines the structure of a valid result for the function.
+  """
+  handleResult(
+    """
+    The result of the function.
+    """
+    result: FunctionResult!
+  ): Void!
+}
+
+input OrderMinimumSubtotal {
+  excludedVariantIds: [ID!]!
+  minimumAmount: Float!
+  targetType: TargetType!
+}
+
+input OrderSubtotalTarget {
+  excludedVariantIds: [ID!]!
+}
+
+input Percentage {
+  value: Float!
+}
+
 type Product implements HasMetafields {
   giftCard: Boolean
-  id: UnsignedInt64!
+  id: ID!
 
   """
   Returns a metafield by namespace and key that belongs to the resource.
@@ -135,13 +201,40 @@ type Product implements HasMetafields {
   vendor: String
 }
 
+input ProductMinimumQuantity {
+  ids: [ID!]!
+  minimumQuantity: Int!
+  targetType: TargetType!
+}
+
+input ProductMinimumSubtotal {
+  ids: [ID!]!
+  minimumAmount: Float!
+  targetType: TargetType!
+}
+
+input ProductVariantTarget {
+  id: ID!
+  quantity: Int
+}
+
 type Property {
   key: String!
   value: String!
 }
 
 type SellingPlan {
-  id: UnsignedInt64!
+  id: ID!
+}
+
+input Target @oneOf {
+  orderSubtotal: OrderSubtotalTarget
+  productVariant: ProductVariantTarget
+}
+
+enum TargetType {
+  ORDER_SUBTOTAL
+  PRODUCT_VARIANT
 }
 
 """
@@ -150,9 +243,14 @@ Example value: `1099511627776`
 """
 scalar UnsignedInt64
 
+input Value @oneOf {
+  fixedAmount: FixedAmount
+  percentage: Percentage
+}
+
 type Variant implements HasMetafields {
   compareAtPrice: Money
-  id: UnsignedInt64!
+  id: ID!
 
   """
   Returns a metafield by namespace and key that belongs to the resource.
@@ -172,3 +270,8 @@ type Variant implements HasMetafields {
   sku: String
   title: String
 }
+
+"""
+A void type that can be used to return a null value from a mutation.
+"""
+scalar Void


### PR DESCRIPTION
Rust examples for:

- `product_discounts`: percentage off products with excluded variant ids
- `order_discounts`: percentage off order with excluded variant ids
- `shipping_discounts`: percentage off shipping

🎩 

### Login to Shopify CLI

```sh
SPIN=1 shopify login
```

Use `partners@shopify.com` with Italic Apps 

### Build and push scripts

```sh
shopify script create --api=product_discounts --language=rust --branch=discounts/new-rust --title=rust_p && cd rust_p && make && SPIN=1 shopify script push
```

```sh
shopify script create --api=order_discounts --language=rust --branch=discounts/new-rust --title=rust_o && cd rust_o && make && SPIN=1 shopify script push
```

```sh
shopify script create --api=shipping_discounts --language=rust --branch=discounts/new-rust --title=rust_s && cd rust_s && make && SPIN=1 shopify script push
```

```sh
Are you working on a Shopify project on behalf of the Shopify partners org? (Choose with ↑ ↓ ⏎)
> 1. no

Which partner organization do you want to use? (Choose with ↑ ↓ ⏎, filter with 'f')
> 1. Italic Apps (1)
```
