### PR TITLE
Fix payment method rust make file

### DIFF
--- a/checkout/rust/payment-methods/default/Makefile
+++ b/checkout/rust/payment-methods/default/Makefile
@@ -1,3 +1,4 @@
 build_wasm:
+	mkdir -p build/ && \
 	cargo build --release --target "wasm32-wasi" && \
-	cp target/wasm32-wasi/release/*.wasm build/index.wasm
+	wasm-opt -O3 --strip-debug target/wasm32-wasi/release/*.wasm -o \build/index.wasm


### PR DESCRIPTION
This fixes 2 problems

- `mkdir build/` if that directory doesn't already exist
- reduces the `wasm` size below 256kb