### PR TITLE
Add App Bridge paths to samples

### DIFF
--- a/checkout/rust/payment-methods/default/.shopify-cli.yml
+++ b/checkout/rust/payment-methods/default/.shopify-cli.yml
@@ -5,3 +5,5 @@ extension_point_type: payment_methods
 title: Default Payment Methods Script
 description: Template script that does nothing
 language: rust
+app_bridge_create_path: /
+app_bridge_details_path: /

--- a/checkout/rust/shipping-methods/default/.shopify-cli.yml
+++ b/checkout/rust/shipping-methods/default/.shopify-cli.yml
@@ -5,3 +5,5 @@ extension_point_type: shipping_methods
 title: Default Shipping Methods Script
 description: Template script that renames first shipping method
 language: wasm
+app_bridge_create_path: /
+app_bridge_details_path: /

--- a/checkout/rust/shipping-rate-presenter/default/.shopify-cli.yml
+++ b/checkout/rust/shipping-rate-presenter/default/.shopify-cli.yml
@@ -1,7 +1,9 @@
 ---
 project_type: :script
 organization_id: 0
-extension_point_type: shipping_rate_presenter 
-title: Default 
-description: 
+extension_point_type: shipping_rate_presenter
+title: Default
+description:
 language: rust
+app_bridge_create_path: /
+app_bridge_details_path: /


### PR DESCRIPTION
This PR adds default App Bridge paths to the samples.

Issue: https://github.com/Shopify/script-service/issues/4712