### PR TITLE
Redirect to discounts index instead of /apps

### DIFF
--- a/sample-apps/discount-functions-sample-app/web/frontend/hooks/useRedirectToDiscounts.js
+++ b/sample-apps/discount-functions-sample-app/web/frontend/hooks/useRedirectToDiscounts.js
@@ -2,13 +2,13 @@ import { useAppBridge } from '@shopify/app-bridge-react';
 import { Redirect } from '@shopify/app-bridge/actions';
 import { useCallback } from 'react';
 
-const APP_DISCOUNTS_PATH = '/discounts/apps';
-
 export function useRedirectToDiscounts() {
   const app = useAppBridge();
 
   return useCallback(() => {
     const redirect = Redirect.create(app);
-    redirect.dispatch(Redirect.Action.ADMIN_PATH, APP_DISCOUNTS_PATH);
+    redirect.dispatch(Redirect.Action.ADMIN_SECTION, {
+      name: Redirect.ResourceType.Discount,
+    });
   }, [app]);
 }


### PR DESCRIPTION
### What?

The `/discounts/apps` route was temporary during development. Instead, merchants should be redirected to the `/discounts` route.

### How?

All the discounts redirects in the discounts sample app are through the `useRedirectToDiscounts` hook. This hook was updated to use the correct App Bridge redirect.

### Checklist

#### Before Merging

- [x] I have 🎩'd this locally
- [x] I have requested reviews or pinged the relevant persons/teams

### Tophat

Test it out here: https://andrews-fine-merchandise.myshopify.com/admin/discounts

If my app isn't running, just ping me on Slack and I can restart it.