### PR TITLE
Fix broken redirect on GraphQL 403

### DIFF
--- a/sample-apps/discount-functions-sample-app/web/frontend/hooks/useAuthenticatedFetch.js
+++ b/sample-apps/discount-functions-sample-app/web/frontend/hooks/useAuthenticatedFetch.js
@@ -1,28 +1,42 @@
-import { authenticatedFetch } from "@shopify/app-bridge-utils";
-import { useAppBridge } from "@shopify/app-bridge-react";
-import { Redirect } from "@shopify/app-bridge/actions";
+import { authenticatedFetch } from '@shopify/app-bridge-utils'
+import { useAppBridge } from '@shopify/app-bridge-react'
+import { Redirect } from '@shopify/app-bridge/actions'
 
+/**
+ * A hook that returns an auth-aware fetch function.
+ * @desc The returned fetch function that matches the browser's fetch API
+ * See: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
+ * It will provide the following functionality:
+ *
+ * 1. Add a `X-Shopify-Access-Token` header to the request.
+ * 2. Check response for `X-Shopify-API-Request-Failure-Reauthorize` header.
+ * 3. Redirect the user to the reauthorization URL if the header is present.
+ *
+ * @returns {Function} fetch function
+ */
 export function useAuthenticatedFetch() {
-  const app = useAppBridge();
-  const fetchFunction = authenticatedFetch(app);
+  const app = useAppBridge()
+  const fetchFunction = authenticatedFetch(app)
 
   return async (uri, options) => {
-    const response = await fetchFunction(uri, options);
-    checkHeadersForReauthorization(response.headers, app);
-    return response;
-  };
+    const response = await fetchFunction(uri, options)
+    checkHeadersForReauthorization(response.headers, app)
+    return response
+  }
 }
 
 function checkHeadersForReauthorization(headers, app) {
-  if (headers.get("X-Shopify-API-Request-Failure-Reauthorize") === "1") {
+  if (headers.get('X-Shopify-API-Request-Failure-Reauthorize') === '1') {
     const authUrlHeader =
-      headers.get("X-Shopify-API-Request-Failure-Reauthorize-Url") ||
-      `/api/auth`;
+      headers.get('X-Shopify-API-Request-Failure-Reauthorize-Url') ||
+      `/api/auth`
 
-    const redirect = Redirect.create(app);
-    const redirectType = authUrlHeader.startsWith("/")
-      ? Redirect.Action.APP
-      : Redirect.Action.REMOTE;
-    redirect.dispatch(redirectType, authUrlHeader);
+    const redirect = Redirect.create(app)
+    redirect.dispatch(
+      Redirect.Action.REMOTE,
+      authUrlHeader.startsWith('/')
+        ? `https://${window.location.host}${authUrlHeader}`
+        : authUrlHeader
+    )
   }
 }


### PR DESCRIPTION
Update `useAuthenticatedFetch` to match the updated template[1]
to include the fix from Shopify/shopify-frontend-template-react#66.

See linked PR for more details.

Note that the experience is still a little broken: on a 403, we
redirect to the auth flow, lose the user input and their current page,
we end up landing on the app's home page.

But at least that's better than the current state of things.

[1]: https://github.com/Shopify/shopify-frontend-template-react/blob/a49d4aa7d1f425e32b8440efd63e00519b321af8/hooks/useAuthenticatedFetch.js