### PR TITLE
Use functionId instead of scriptUuid

### DIFF
--- a/sample-apps/discount-functions-sample-app/web/frontend/components/DiscountCreatePage.jsx
+++ b/sample-apps/discount-functions-sample-app/web/frontend/components/DiscountCreatePage.jsx
@@ -14,7 +14,7 @@ import { useRedirectToDiscounts } from '../hooks/useRedirectToDiscounts';
 import { serializeDiscount } from '../utilities/serializeDiscount';
 
 export default function DiscountCreatePage({
-  scriptUuid,
+  functionId,
   defaultConfiguration,
   renderConfigurationForm,
 }) {
@@ -30,7 +30,7 @@ export default function DiscountCreatePage({
   const handleCreateDiscount = async () => {
     setIsError(false);
     try {
-      await createDiscount(scriptUuid, serializeDiscount(discount));
+      await createDiscount(functionId, serializeDiscount(discount));
     } catch {
       setIsError(true);
       return;

--- a/sample-apps/discount-functions-sample-app/web/frontend/pages/order-discount/new.jsx
+++ b/sample-apps/discount-functions-sample-app/web/frontend/pages/order-discount/new.jsx
@@ -7,7 +7,7 @@ import {
 export default function CreateOrderDiscountPage() {
   return (
     <DiscountCreatePage
-      scriptUuid={process.env.ORDER_DISCOUNT_ID}
+      functionId={process.env.ORDER_DISCOUNT_ID}
       defaultConfiguration={DEFAULT_CONFIGURATION}
       renderConfigurationForm={(configuration, onConfigurationChange) => (
         <OrderDiscount

--- a/sample-apps/discount-functions-sample-app/web/frontend/pages/product-discount/new.jsx
+++ b/sample-apps/discount-functions-sample-app/web/frontend/pages/product-discount/new.jsx
@@ -7,7 +7,7 @@ import {
 export default function CreateProductDiscountPage() {
   return (
     <DiscountCreatePage
-      scriptUuid={process.env.PRODUCT_DISCOUNT_ID}
+      functionId={process.env.PRODUCT_DISCOUNT_ID}
       defaultConfiguration={DEFAULT_CONFIGURATION}
       renderConfigurationForm={(configuration, onConfigurationChange) => (
         <ProductDiscount

--- a/sample-apps/discount-functions-sample-app/web/frontend/pages/shipping-discount/new.jsx
+++ b/sample-apps/discount-functions-sample-app/web/frontend/pages/shipping-discount/new.jsx
@@ -7,7 +7,7 @@ import {
 export default function CreateShippingDiscountPage() {
   return (
     <DiscountCreatePage
-      scriptUuid={process.env.SHIPPING_DISCOUNT_ID}
+      functionId={process.env.SHIPPING_DISCOUNT_ID}
       defaultConfiguration={DEFAULT_CONFIGURATION}
       renderConfigurationForm={(configuration, onConfigurationChange) => (
         <ShippingDiscount


### PR DESCRIPTION
This PR updates the discounts sample app to use the `functionId` field instead of `scriptUuid` when creating a discount. 

Related issue: https://github.com/Shopify/script-service/issues/4950